### PR TITLE
Disable JPA caching so that DB changes are picked up.

### DIFF
--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/controller/MetadataController.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/controller/MetadataController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.annotation.RequestScope;
 import uk.co.onsdigital.discovery.metadata.api.exception.DataSetNotFoundException;
 import uk.co.onsdigital.discovery.metadata.api.exception.DimensionNotFoundException;
 import uk.co.onsdigital.discovery.metadata.api.model.DataSet;
@@ -105,6 +106,7 @@ public class MetadataController {
     }
 
     @Bean
+    @RequestScope
     public EntityManager getEntityManager(final EntityManagerFactory emf) {
         return emf.createEntityManager();
     }

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -31,6 +31,9 @@
             <property name="javax.persistence.jdbc.user" value="data_discovery" />
             <property name="javax.persistence.jdbc.password" value="password" />
             <property name="eclipselink.logging.level" value="INFO" />
+            <!-- Disable the EclipseLink shared entity cache as we expect another service (the loader) to be changing
+                 the database directly. -->
+            <property name="eclipselink.cache.shared.default" value="false"/>
 
             <!--<property name="javax.persistence.schema-generation.database.action" value="drop-and-create"/>-->
             <property name="javax.persistence.schema-generation.scripts.action" value="drop-and-create"/>


### PR DESCRIPTION
### What

Giri's testing showed that the API was not picking up changes that were made directly in the database. It seems to pick up new inserts, but not deletions or updates. Although non-insert changes to the database should be rare/never in production, we may have to support them and it is useful during development. This therefore disables the EclipseLink shared object cache (https://wiki.eclipse.org/EclipseLink/Examples/JPA/Caching). 

It also configures the JPA EntityManager to be request scoped rather than a singleton, as this is the intended usage (EM is not thread-safe and is intended to be used per-transaction/session).

### How to review

Load some data into the database and view the dimensions for a dataset using the API. Delete an option from a dimension via commands like:

```sql
DELETE FROM variable_category WHERE category_id = 7; -- Example id...
DELETE FROM category WHERE category_id = 7;
```

Refresh the API page and check that the option has disappeared.

### Who can review

Anyone but me.