### PR TITLE
Change the default port to avoid clash with Babbage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ java -jar target/dd-dimensional-metadata-api-1.0.0-SNAPSHOT.jar
 This will start the server running on port 8080 talking to a local PostgreSQL database. Use the
 following environment variables to configure the system:
 
- * `BASE_URL`: Base URL to use when constructing links to resources. Defaults to `http://localhost:8080`.
+ * `BASE_URL`: Base URL to use when constructing links to resources. Defaults to `http://localhost:20098`. NB: this
+ should be the public URL that the API is available from if it is behind a load-balancer/proxy etc.
+ * `SERVER_PORT`: The port to listen on. Defaults to `20098`.
  * `DB_USER`: The database username. Defaults to `data_discovery`.
  * `DB_PASSWORD`: The database password. Defaults to `password`.
  * `DB_URL`: The database JDBC URL. Defaults to `jdbc:postgresql://localhost:5432/data_discovery`.

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/UrlBuilder.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/UrlBuilder.java
@@ -20,7 +20,7 @@ public class UrlBuilder {
     private final UriTemplate dimensionsTemplate;
     private final UriTemplate dimensionTemplate;
 
-    UrlBuilder(@Value("#{systemEnvironment['BASE_URL'] ?: 'http://localhost:8080'}") String baseUrl) {
+    UrlBuilder(@Value("#{systemEnvironment['BASE_URL'] ?: 'http://localhost:20098'}") String baseUrl) {
         this.baseUrl = requireNonNull(baseUrl);
 
         pageTemplate = new UriTemplate(baseUrl + "/datasets?page={page}&size={size}");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+server.port=20098


### PR DESCRIPTION
### What

Change the default server port from 8080 to 20098. Document env variable to change the port.

### How to review

1. `mvn clean package`
2. `java -jar target/dd-*.jar`
3. Check that tomcat starts on port 20098 and that links generated by the API also use that port.
4. Restart the server with `BASE_URL='http://localhost:8090' SERVER_PORT=8090 java -jar target/dd-*.jar` and check that it starts on port 8090 and with correct links.

### Who can review

Anyone but me.