### PR TITLE
Expose geographies as dimensions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,11 @@
             <artifactId>postgresql</artifactId>
             <version>9.4.1212</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>20.0</version>
+        </dependency>
 
         <dependency>
             <groupId>org.testng</groupId>

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dao/MetadataDao.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dao/MetadataDao.java
@@ -1,9 +1,11 @@
 package uk.co.onsdigital.discovery.metadata.api.dao;
 
-import uk.co.onsdigital.discovery.metadata.api.exception.DataSetNotFoundException;
 import uk.co.onsdigital.discovery.metadata.api.exception.ConceptSystemNotFoundException;
+import uk.co.onsdigital.discovery.metadata.api.exception.DataSetNotFoundException;
+import uk.co.onsdigital.discovery.metadata.api.exception.GeographicHierarchyNotFoundException;
 import uk.co.onsdigital.discovery.model.ConceptSystem;
 import uk.co.onsdigital.discovery.model.DimensionalDataSet;
+import uk.co.onsdigital.discovery.model.GeographicAreaHierarchy;
 
 import java.util.List;
 import java.util.Set;
@@ -57,4 +59,16 @@ public interface MetadataDao {
      */
     ConceptSystem findConceptSystemByDataSetAndConceptSystemName(String dataSetId, String conceptSystem)
             throws DataSetNotFoundException, ConceptSystemNotFoundException;
+
+    /**
+     * Find a given geographic hierarchy that is referenced in a given dataset.
+     *
+     * @param dataSetId the id of the dataset.
+     * @param geographyId the name of the geographic hierarchy, such as {@literal 2013ADMIN}.
+     * @return the matching geographic hierarchy if it exists and is referenced in the given dataset.
+     * @throws DataSetNotFoundException if the dataset does not exist.
+     * @throws GeographicHierarchyNotFoundException if the geographic hierarchy does not exist or is not referenced in the given dataset.
+     */
+    GeographicAreaHierarchy findGeographyInDataSet(String dataSetId, String geographyId)
+            throws DataSetNotFoundException, GeographicHierarchyNotFoundException;
 }

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dao/MetadataDaoImpl.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dao/MetadataDaoImpl.java
@@ -3,12 +3,15 @@ package uk.co.onsdigital.discovery.metadata.api.dao;
 import org.springframework.stereotype.Repository;
 import uk.co.onsdigital.discovery.metadata.api.exception.ConceptSystemNotFoundException;
 import uk.co.onsdigital.discovery.metadata.api.exception.DataSetNotFoundException;
+import uk.co.onsdigital.discovery.metadata.api.exception.GeographicHierarchyNotFoundException;
 import uk.co.onsdigital.discovery.model.ConceptSystem;
 import uk.co.onsdigital.discovery.model.DimensionalDataSet;
+import uk.co.onsdigital.discovery.model.GeographicAreaHierarchy;
 
 import javax.persistence.EntityManager;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
@@ -60,5 +63,18 @@ public class MetadataDaoImpl implements MetadataDao {
                 .filter(c -> conceptSystemName.equals(c.getConceptSystem()))
                 .findAny()
                 .orElseThrow(() -> new ConceptSystemNotFoundException("No such concept system in dataset: " + conceptSystemName));
+    }
+
+    @Override
+    public GeographicAreaHierarchy findGeographyInDataSet(String dataSetId, String geographyId)
+            throws DataSetNotFoundException, GeographicHierarchyNotFoundException {
+
+        // FIXME: this is a provisional inefficient implementation for the current prototype.
+        // At some point the metadata database will be redesigned to not store data points, at which point this should be optimised.
+        final DimensionalDataSet dataSet = findDataSetById(dataSetId);
+        return dataSet.getReferencedGeographies()
+                .filter(geog -> Objects.equals(geog.getGeographicAreaHierarchy(), geographyId))
+                .findAny()
+                .orElseThrow(() -> new GeographicHierarchyNotFoundException(geographyId));
     }
 }

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/exception/ConceptSystemNotFoundException.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/exception/ConceptSystemNotFoundException.java
@@ -1,8 +1,8 @@
 package uk.co.onsdigital.discovery.metadata.api.exception;
 
 /**
- * Exception thrown by the {@link uk.co.onsdigital.discovery.metadata.api.dao.MetadataDao} to indicate that a variable
- * was not found in the database. A <em>Variable</em> in the data layer is equivalent to a <em>Dimension</em> at the API
+ * Exception thrown by the {@link uk.co.onsdigital.discovery.metadata.api.dao.MetadataDao} to indicate that a concept system
+ * was not found in the database. A <em>ConceptSystem</em> in the data layer is represented as a <em>Dimension</em> at the API
  * layer.
  */
 public class ConceptSystemNotFoundException extends DimensionNotFoundException {

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/exception/GeographicHierarchyNotFoundException.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/exception/GeographicHierarchyNotFoundException.java
@@ -1,0 +1,12 @@
+package uk.co.onsdigital.discovery.metadata.api.exception;
+
+/**
+ * Exception thrown by the {@link uk.co.onsdigital.discovery.metadata.api.dao.MetadataDao} to indicate that a geographic
+ * hierarchy was not found in the database. A <em>GeographicHierarchy</em> in the data layer is exposed as (one type of)
+ * <em>Dimension</em> at the API layer.
+ */
+public class GeographicHierarchyNotFoundException extends DimensionNotFoundException {
+    public GeographicHierarchyNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/model/DimensionOption.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/model/DimensionOption.java
@@ -1,6 +1,13 @@
 package uk.co.onsdigital.discovery.metadata.api.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.Ordering;
+
 import java.util.Objects;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * A possible option for a dimension, such as <em>Male</em> or <em>Female</em> for the dimension <em>Sex</em>.
@@ -8,6 +15,7 @@ import java.util.Objects;
 public class DimensionOption implements Comparable<DimensionOption> {
     private final String id;
     private final String name;
+    private final SortedSet<DimensionOption> options = new TreeSet<>();
 
     public DimensionOption(String id, String name) {
         this.id = id;
@@ -22,9 +30,22 @@ public class DimensionOption implements Comparable<DimensionOption> {
         return name;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Set<DimensionOption> getOptions() {
+        return options;
+    }
+
+    public void addOption(DimensionOption option) {
+        this.options.add(option);
+    }
+
     @Override
     public int compareTo(DimensionOption that) {
-        return Objects.compare(this.name, that.name, String.CASE_INSENSITIVE_ORDER);
+        return ComparisonChain.start()
+                .compare(this.id, that.id, String.CASE_INSENSITIVE_ORDER)
+                .compare(this.name, that.name, String.CASE_INSENSITIVE_ORDER)
+                .compare(this.options, that.options, Ordering.natural().lexicographical())
+                .result();
     }
 
     @Override
@@ -42,6 +63,7 @@ public class DimensionOption implements Comparable<DimensionOption> {
         return "DimensionOption{" +
                 "id='" + id + '\'' +
                 ", name='" + name + '\'' +
+                ", options=" + options +
                 '}';
     }
 }

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/model/DimensionOption.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/model/DimensionOption.java
@@ -41,6 +41,7 @@ public class DimensionOption implements Comparable<DimensionOption> {
 
     @Override
     public int compareTo(DimensionOption that) {
+        // Note: we only really need to compare IDs here, but compare everything to simplify unit test comparisons.
         return ComparisonChain.start()
                 .compare(this.id, that.id, String.CASE_INSENSITIVE_ORDER)
                 .compare(this.name, that.name, String.CASE_INSENSITIVE_ORDER)


### PR DESCRIPTION
### What

Exposes the geographical hierarchies referenced by a dataset as dimensions to conform with the stub API. Extends the model to cope with hierarchical dimensions. Note: this work does not include any of the dedicated geography endpoints (`/geoareas` etc) in the stub as that is covered by a different ticket.

### How to review

`mvn clean package && java -jar target/dd-*.jar` will run the tests and launch the API. Then load a dataset with hierarchical geography data and check the dimensions.

### Who can review

Anyone apart from me.