### PR TITLE
Add feature flag to disable geography dimensions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ following environment variables to configure the system:
  * `DB_PASSWORD`: The database password. Defaults to `password`.
  * `DB_URL`: The database JDBC URL. Defaults to `jdbc:postgresql://localhost:5432/data_discovery`.
  * `DB_DRIVER`: The JDBC driver to load. Defaults to `org.postgresql.Driver`.
+ * `INCLUDE_GEO_DIMENSIONS`: Whether to expose geographical hierarchies as dimensions. Defaults to `false`.
 
 ## Contributing
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 server.port=20099
+include.geo.dimensions=false

--- a/src/test/java/uk/co/onsdigital/discovery/metadata/api/service/MetadataServiceTest.java
+++ b/src/test/java/uk/co/onsdigital/discovery/metadata/api/service/MetadataServiceTest.java
@@ -44,7 +44,7 @@ public class MetadataServiceTest {
     @BeforeMethod
     public void createMetadataService() {
         MockitoAnnotations.initMocks(this);
-        metadataService = new MetadataServiceImpl(mockDao, new UrlBuilder(BASE_URL));
+        metadataService = new MetadataServiceImpl(mockDao, new UrlBuilder(BASE_URL), true);
     }
 
     @Test


### PR DESCRIPTION
### What

Adds a config option/env variable to disable exposing geographies as dimensions by default. This is to allow the demo to work without significant refactoring.

### How to review

1. `mvn clean spring-boot:run` then browse API and check that the geography dimensions do not show up anywhere
2. `INCLUDE_GEO_DIMENSIONS=true mvn clean spring-boot:run` and check that they do.

### Who can review

Anyone but me.