### PR TITLE
Expose additional descriptive metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.github.ONSdigital</groupId>
             <artifactId>dp-dd-backend-model</artifactId>
-            <version>develop-SNAPSHOT</version>
+            <version>feature~metadata-SNAPSHOT</version>
         </dependency>
 <!--
         <dependency>

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/model/DataSet.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/model/DataSet.java
@@ -2,9 +2,9 @@ package uk.co.onsdigital.discovery.metadata.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import uk.co.onsdigital.discovery.model.Metadata;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -91,35 +91,5 @@ public class DataSet {
                 ", url='" + url + '\'' +
                 ", metadata=" + metadata +
                 '}';
-    }
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    public static class Metadata {
-        private String description;
-        private List<String> taxonomies;
-
-        public String getDescription() {
-            return description;
-        }
-
-        public void setDescription(String description) {
-            this.description = description;
-        }
-
-        public List<String> getTaxonomies() {
-            return taxonomies;
-        }
-
-        public void setTaxonomies(List<String> taxonomies) {
-            this.taxonomies = taxonomies;
-        }
-
-        @Override
-        public String toString() {
-            return "Metadata{" +
-                    "description='" + description + '\'' +
-                    ", taxonomies=" + taxonomies +
-                    '}';
-        }
     }
 }

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/MetadataServiceImpl.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/MetadataServiceImpl.java
@@ -92,10 +92,7 @@ public class MetadataServiceImpl implements MetadataService {
         dataSet.setId(dbDataSet.getDimensionalDataSetId().toString());
         dataSet.setTitle(dbDataSet.getTitle());
         dataSet.setS3URL(dbDataSet.getS3URL());
-        dataSet.setDescription(dbDataSet.getDescription());
-        if (dataSet.getMetadata().getDescription() == null) {
-            dataSet.setDescription("No description available.");
-        }
+        dataSet.setMetadata(dbDataSet.getMetadata());
         dataSet.setUrl(urlBuilder.dataset(dataSet.getId()));
         dataSet.setDimensionsUrl(urlBuilder.dimensions(dataSet.getId()));
 

--- a/src/test/java/uk/co/onsdigital/discovery/metadata/api/service/MetadataServiceTest.java
+++ b/src/test/java/uk/co/onsdigital/discovery/metadata/api/service/MetadataServiceTest.java
@@ -289,14 +289,14 @@ public class MetadataServiceTest {
     private static void assertDataSetEqualsDbModel(final DataSet actual, final DimensionalDataSet expected) {
         assertThat(actual.getId()).isEqualTo(expected.getDimensionalDataSetId().toString());
         assertThat(actual.getS3URL()).isEqualTo(expected.getS3URL());
-        assertThat(actual.getMetadata().getDescription()).isEqualTo(expected.getDescription());
+        assertThat(actual.getMetadata().getDescription()).isEqualTo(expected.getMetadata().getDescription());
     }
 
     private DimensionalDataSet dbDataSet(UUID dataSetId, String s3URL, String description) {
         DimensionalDataSet dataSet = new DimensionalDataSet();
         dataSet.setDimensionalDataSetId(dataSetId);
         dataSet.setS3URL(s3URL);
-        dataSet.setDescription(description);
+        dataSet.getMetadata().setDescription(description);
         return dataSet;
     }
 }


### PR DESCRIPTION
### What

Exposes the additional metadata added to the database model, needed for the dataset details UI page.

Note: this does not yet include the dataset landing page details (data resource) as this is likely to change pending the discussion on Monday around naming.

### How to review

1. Check out and build.
2. Load in a dataset.
3. Run the SQL below to populate the metadata for your datasets.
4. Compare the output to the stub and check for differences.

```sql
update dimensional_data_set
   SET contact = 'Jimmy Jimbob',
       contact_email = 'jimmy@example.com',
       contact_phone = '+44 (0)1234 567890',
       description = 'A test dataset.',
       release_date = '2 January 2016',
       next_release = 'To be confirmed',
       nationalstatistics = true,
       methodology = 'http://www.ons.gov.uk/methodology/blah',
       termsandconditions = 'Some legal stuff here.';
insert into associated_publications(dimensional_data_set_id, associated_publication_url)
  SELECT dimensional_data_set_id, 'http://example.com/blah' from dimensional_data_set;
```
### Who can review

Anyone but me.