### PR TITLE
Make jenkins use latest maven dependencies when building.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ node {
     def revision = revisionFrom(readFile('git-tag').trim(), readFile('git-commit').trim())
 
     stage('Build') {
-        sh "${tool 'm3'}/bin/mvn clean package"
+        sh "${tool 'm3'}/bin/mvn -U clean package"
     }
 
     stage('Image') {


### PR DESCRIPTION
### What

Adds a `-U` argument to the Maven build in Jenkins to ensure it always picks up the latest versions of snapshot dependencies.

### How to review

Eyeball

### Who can review

Anyone but me. @LloydGriffiths 