### PR TITLE
Add support for view=hierarchy

### DIFF
--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/controller/MetadataController.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/controller/MetadataController.java
@@ -103,6 +103,7 @@ public class MetadataController {
     @ResponseStatus(code = HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(RuntimeException.class)
     public ErrorResponse onRuntimeException(final RuntimeException ex) {
+        logger.error("Unhandled exception: {}", ex.getMessage(), ex);
         return new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
     }
 

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/DimensionMetadata.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/DimensionMetadata.java
@@ -55,4 +55,15 @@ public class DimensionMetadata {
     public void setOptions(List<DimensionOption> options) {
         this.options = options;
     }
+
+    @Override
+    public String toString() {
+        return "DimensionMetadata{" +
+                "name='" + name + '\'' +
+                ", type='" + type + '\'' +
+                ", hierarchical=" + hierarchical +
+                ", url='" + url + '\'' +
+                ", options=" + options +
+                '}';
+    }
 }

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/DimensionOption.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/DimensionOption.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.co.onsdigital.discovery.model.HierarchyLevelType;
 
-import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -16,9 +16,9 @@ public class DimensionOption {
     private String code;
     private String name;
     private HierarchyLevelType levelType;
-    private List<DimensionOption> children;
+    private Set<DimensionOption> children;
 
-    public DimensionOption(UUID id, String code, String name, HierarchyLevelType levelType, List<DimensionOption> children) {
+    public DimensionOption(UUID id, String code, String name, HierarchyLevelType levelType, Set<DimensionOption> children) {
         this.id = id;
         this.code = code;
         this.name = name;
@@ -34,6 +34,7 @@ public class DimensionOption {
         this(id, null, name);
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public UUID getId() {
         return id;
     }
@@ -52,8 +53,14 @@ public class DimensionOption {
 
     @JsonProperty("options")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<DimensionOption> getChildren() {
+    public Set<DimensionOption> getChildren() {
         return children;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    @JsonProperty(defaultValue = "false")
+    public boolean isEmpty() {
+        return id == null;
     }
 
     @Override
@@ -73,10 +80,7 @@ public class DimensionOption {
         if (name != null ? !name.equals(that.name) : that.name != null) {
             return false;
         }
-        if (levelType != null ? !levelType.equals(that.levelType) : that.levelType != null) {
-            return false;
-        }
-        return children != null ? children.equals(that.children) : that.children == null;
+        return levelType != null ? levelType.equals(that.levelType) : that.levelType == null;
     }
 
     @Override
@@ -84,7 +88,6 @@ public class DimensionOption {
         int result = code != null ? code.hashCode() : 0;
         result = 31 * result + (name != null ? name.hashCode() : 0);
         result = 31 * result + (levelType != null ? levelType.hashCode() : 0);
-        result = 31 * result + (children != null ? children.hashCode() : 0);
         return result;
     }
 }

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/DimensionOption.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/DimensionOption.java
@@ -90,4 +90,15 @@ public class DimensionOption {
         result = 31 * result + (levelType != null ? levelType.hashCode() : 0);
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "DimensionOption{" +
+                "id=" + id +
+                ", code='" + code + '\'' +
+                ", name='" + name + '\'' +
+                ", levelType=" + levelType +
+                ", children=" + children +
+                '}';
+    }
 }

--- a/src/test/java/uk/co/onsdigital/discovery/metadata/api/service/DimensionViewTypeTest.java
+++ b/src/test/java/uk/co/onsdigital/discovery/metadata/api/service/DimensionViewTypeTest.java
@@ -1,0 +1,214 @@
+package uk.co.onsdigital.discovery.metadata.api.service;
+
+import org.testng.annotations.Test;
+import uk.co.onsdigital.discovery.metadata.api.dto.DimensionOption;
+import uk.co.onsdigital.discovery.model.DimensionValue;
+import uk.co.onsdigital.discovery.model.Hierarchy;
+import uk.co.onsdigital.discovery.model.HierarchyEntry;
+import uk.co.onsdigital.discovery.model.HierarchyLevelType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.util.CollectionUtils.isEmpty;
+
+public class DimensionViewTypeTest {
+    private static final HierarchyLevelType ROOT_LEVEL = new HierarchyLevelType();
+    static {
+        ROOT_LEVEL.setName("root");
+        ROOT_LEVEL.setLevel(0);
+    }
+
+    @Test
+    public void viewTypeNoneShouldAlwaysReturnNull() {
+        List<DimensionValue> values = Arrays.asList(new DimensionValue(UUID.randomUUID(), "a", "1"), new DimensionValue(UUID.randomUUID(), "b", "2"));
+        assertThat(DimensionViewType.NONE.convertValues(values)).isNull();
+    }
+
+    @Test
+    public void viewTypeListShouldReturnAFlatListForHierarchicalDimensions() {
+        final List<DimensionValue> values = getTestDimensionValues(getTestHierarchy());
+        final List<DimensionOption> options = DimensionViewType.LIST.convertValues(values);
+
+        assertThat(options).hasSize(values.size());
+        assertThat(options).allMatch(option -> isEmpty(option.getChildren()));
+    }
+
+    @Test
+    public void viewTypeListShouldReturnAFlatListForFlatDimensions() {
+        final List<DimensionValue> values = getTestDimensionValues(Collections.emptyMap());
+        final List<DimensionOption> options = DimensionViewType.LIST.convertValues(values);
+
+        assertThat(options).hasSize(values.size());
+        assertThat(options).allMatch(option -> isEmpty(option.getChildren()));
+    }
+
+    @Test
+    public void viewTypeListShouldUseHierarchyInfoWhenPresent() {
+        final List<DimensionValue> values = getTestDimensionValues(getTestHierarchy());
+        final List<DimensionOption> options = DimensionViewType.LIST.convertValues(values);
+
+        assertThat(options).hasSize(values.size());
+        for (int i = 0; i < values.size(); ++i) {
+            DimensionValue value = values.get(i);
+            DimensionOption option = options.get(i);
+
+            assertThat(option.getId()).isNotNull();
+            assertThat(option.getName()).isEqualTo(value.getHierarchyEntry().getName());
+            assertThat(option.getCode()).isEqualTo(value.getHierarchyEntry().getCode());
+            assertThat(option.getLevelType()).isEqualTo(value.getHierarchyEntry().getLevelType());
+        }
+    }
+
+    @Test
+    public void viewTypeHierarchyShouldReturnFlatListForFlatDimensions() {
+        final List<DimensionValue> values = getTestDimensionValues(Collections.emptyMap());
+        final List<DimensionOption> options = DimensionViewType.HIERARCHY.convertValues(values);
+
+        assertThat(options).hasSize(values.size());
+        assertThat(options).allMatch(option -> option.getChildren() == null);
+    }
+
+    @Test
+    public void viewTypeHierarchyShouldReturnSparseHierarchies() {
+        final List<DimensionValue> values = getTestDimensionValues(getTestHierarchy());
+        final List<DimensionOption> options = DimensionViewType.HIERARCHY.convertValues(values);
+
+        // Should only be a single root option in the test data
+        assertThat(options).as("root options").hasSize(1);
+        assertThat(countAll(options)).isEqualTo(values.size());
+
+        // All top-level options should be at the root level
+        assertThat(options).as("top-level options").allMatch(root -> root.getLevelType() == ROOT_LEVEL);
+        assertThat(options.get(0).getChildren()).as("first-level options").isNotEmpty().allMatch(node -> node.getLevelType().getLevel() == 1);
+    }
+
+    @Test
+    public void viewTypeHierarchyShouldCreateEmptyLevelsWhenMissingInData() {
+        final HierarchyEntry england = getEnglandHierarchy();
+        final DimensionValue value = new DimensionValue(UUID.randomUUID(), "testName", "testValue");
+        value.setHierarchyEntry(england);
+
+        final List<DimensionOption> roots = DimensionViewType.HIERARCHY.convertValues(singletonList(value));
+
+        // Check that we have "empty" UK and England and Wales entries above the non-empty England entry
+        assertThat(roots).hasSize(1);
+        DimensionOption uk = roots.get(0);
+        assertThat(uk.getCode()).isEqualTo("UK");
+        assertThat(uk.getName()).isEqualTo("United Kingdom");
+        assertThat(uk.isEmpty()).isTrue();
+        assertThat(uk.getChildren()).hasSize(1);
+
+        DimensionOption ew = uk.getChildren().iterator().next();
+        assertThat(ew.getCode()).isEqualTo("EW");
+        assertThat(ew.getName()).isEqualTo("England and Wales");
+        assertThat(ew.isEmpty()).isTrue();
+        assertThat(ew.getChildren()).hasSize(1);
+
+        DimensionOption eng = ew.getChildren().iterator().next();
+        assertThat(eng.getCode()).isEqualTo("E");
+        assertThat(eng.getName()).isEqualTo("England");
+        assertThat(eng.isEmpty()).isFalse();
+        assertThat(eng.getChildren()).isNullOrEmpty();
+    }
+
+    private int countAll(Collection<DimensionOption> options) {
+        int count = 0;
+        if (options != null) {
+            for (DimensionOption option : options) {
+                count += countAll(option.getChildren()) + 1;
+            }
+        }
+        return count;
+    }
+
+    private List<DimensionValue> getTestDimensionValues(final Map<String, HierarchyEntry> hierarchyEntryMap) {
+        final List<DimensionValue> values = new ArrayList<>();
+
+        final String dimensionName = "testDimension";
+        final UUID dataSetId = UUID.randomUUID();
+
+        for (int i = 0; i < 100; ++i) {
+            final String code = "value" + i;
+            final DimensionValue value = new DimensionValue(dataSetId, dimensionName, code);
+            if (hierarchyEntryMap.containsKey(code)) {
+                value.setHierarchyEntry(hierarchyEntryMap.get(code));
+            }
+            values.add(value);
+        }
+
+        return values;
+    }
+
+    private Map<String, HierarchyEntry> getTestHierarchy() {
+        final Hierarchy hierarchy = new Hierarchy();
+        hierarchy.setName("Test Hierarchy");
+        hierarchy.setType("test");
+        hierarchy.setId("TH001");
+
+        Map<String, HierarchyEntry> entries = new HashMap<>();
+        Random random = new Random();
+
+        for (int i = 0; i < 100; ++i) {
+            HierarchyEntry entry = new HierarchyEntry();
+            String code = "value" + i;
+            entry.setHierarchy(hierarchy);
+            entry.setName("foo" + i);
+            entry.setCode(code);
+            entry.setDisplayOrder(i);
+            entry.setId(UUID.randomUUID());
+            entry.setLevelType(ROOT_LEVEL);
+
+            // Randomly set a parent entry
+            if (i > 0) {
+                int parent = random.nextInt(i);
+                entry.setParent(entries.get("value" + parent));
+                entry.setLevelType(nextLevelType(entry.getLevelType()));
+            }
+
+            entries.put(code, entry);
+        }
+
+        return entries;
+    }
+
+    private static HierarchyLevelType nextLevelType(HierarchyLevelType parentLevel) {
+        HierarchyLevelType nextLevel = new HierarchyLevelType();
+        nextLevel.setName("test");
+        nextLevel.setLevel(parentLevel.getLevel() + 1);
+        return nextLevel;
+    }
+
+    private static HierarchyEntry getEnglandHierarchy() {
+        final HierarchyEntry uk = new HierarchyEntry();
+        uk.setId(UUID.randomUUID());
+        uk.setCode("UK");
+        uk.setLevelType(ROOT_LEVEL);
+        uk.setName("United Kingdom");
+
+        final HierarchyEntry englandAndWales = new HierarchyEntry();
+        englandAndWales.setId(UUID.randomUUID());
+        englandAndWales.setName("England and Wales");
+        englandAndWales.setLevelType(nextLevelType(ROOT_LEVEL));
+        englandAndWales.setCode("EW");
+        englandAndWales.setParent(uk);
+
+        final HierarchyEntry england = new HierarchyEntry();
+        england.setId(UUID.randomUUID());
+        england.setName("England");
+        england.setLevelType(nextLevelType(englandAndWales.getLevelType()));
+        england.setCode("E");
+        england.setParent(englandAndWales);
+
+        return england;
+    }
+}


### PR DESCRIPTION
### What

Adds support for `?view=hierarchy` to the metadata API. This builds sparse hierarchies which may have "empty" intermediate levels where there is no corresponding value in the data set for that level. These are marked as `"empty":true` in the output and also have no ID.

### How to review

Checkout and `mvn clean spring-boot:run` to run the unit tests and fire it up. Then load in a hierarchical dataset and hit the endpoints to check the output. Example:

```bash
$ curl 'http://localhost:20099/datasets/b04a49e7-0ddd-4c14-8628-1da1588a5e0f/dimensions/Geographic_Area?view=hierarchy' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   589    0   589    0     0   5789      0 --:--:-- --:--:-- --:--:--  5831
{
  "name": "Geographic_Area",
  "url": "http://localhost:20099/datasets/b04a49e7-0ddd-4c14-8628-1da1588a5e0f/dimensions/Geographic_Area",
  "type": "geography",
  "hierarchical": true,
  "options": [
    {
      "code": "K02000001",
      "name": "United Kingdom",
      "levelType": {
        "id": "UK",
        "name": "United Kingdom",
        "level": 0
      },
      "empty": true,
      "options": [
        {
          "code": "K03000001",
          "name": "Great Britain",
          "levelType": {
            "id": "GB",
            "name": "Great Britain",
            "level": 1
          },
          "empty": true,
          "options": [
            {
              "id": "d25e9617-2608-415a-8e8f-407931f59afa",
              "code": "K04000001",
              "name": "England and Wales",
              "levelType": {
                "id": "NAT",
                "name": "England and Wales",
                "level": 2
              }
            }
          ]
        }
      ]
    }
  ]
}
```

### Who can review

Anyone but me. Best if @fullstackforger or somebody else from the front-end team checks that this is the expected behaviour.