### PR TITLE
Ensure dimension options are sorted by level and name.

### DIFF
--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/DimensionOption.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/DimensionOption.java
@@ -90,8 +90,8 @@ public class DimensionOption implements Comparable<DimensionOption> {
     public int compareTo(final DimensionOption that) {
         return ComparisonChain.start()
                 .compare(this.levelType, that.levelType, LevelTypeComparator.INSTANCE)
-                .compare(this.code, that.code, Ordering.natural().nullsLast())
                 .compare(this.name, that.name, Ordering.from(String.CASE_INSENSITIVE_ORDER).nullsLast())
+                .compare(this.code, that.code, Ordering.natural().nullsLast())
                 .result();
     }
 

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/DimensionViewType.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/DimensionViewType.java
@@ -29,6 +29,7 @@ public enum DimensionViewType {
         List<DimensionOption> convertValues(List<DimensionValue> values) {
             return values.stream()
                     .map(DimensionViewType::convertValueToOption)
+                    .sorted()
                     .collect(toList());
         }
     },
@@ -63,7 +64,7 @@ public enum DimensionViewType {
                         final DimensionValue parentValue = valuesByHierarchyEntryId.get(parentEntry.getId());
                         final DimensionOption parent = option(options, parentValue, parentEntry);
 
-                        isNewEntry = parent.getChildren().add(option);
+                        isNewEntry = parent.addChild(option);
                         option = parent;
                     }
                 }
@@ -115,7 +116,7 @@ public enum DimensionViewType {
     private static DimensionOption convertEntryToOption(final DimensionValue dimensionValue, final HierarchyEntry hierarchyEntry) {
         if (hierarchyEntry != null) {
             final UUID id = dimensionValue != null ? dimensionValue.getId() : null;
-            return new DimensionOption(id, hierarchyEntry.getCode(), hierarchyEntry.getName(), hierarchyEntry.getLevelType(), new LinkedHashSet<>());
+            return new DimensionOption(id, hierarchyEntry.getCode(), hierarchyEntry.getName(), hierarchyEntry.getLevelType());
         } else {
             return new DimensionOption(dimensionValue.getId(), dimensionValue.getValue());
         }


### PR DESCRIPTION
### What

The dimension options were previously not ordered in the results. This ensures that they are ordered by hierarchy level (if defined) and then name. If a hierarchy view is requested then each level of the hierarchy will be sorted.

### How to review

`mvn clean spring-boot:run` will run the unit tests and then you can manually verify the results on some loaded datasets.

### Who can review

Anyone but me.