### PR TITLE
Chainging `datasets` legacy endpoints to be `version` to support newer API endpoints

### DIFF
--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/controller/MetadataController.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/controller/MetadataController.java
@@ -64,19 +64,19 @@ public class MetadataController {
         return metadataService.listAvailableDataSets(max(pageable.getPageNumber(), 1), max(pageable.getPageSize(), 1));
     }
 
-    @GetMapping("/version/{dataSetId}")
+    @GetMapping("/versions/{dataSetId}")
     @CrossOrigin
     public DataSet findDataSetById(@PathVariable String dataSetId) throws DataSetNotFoundException {
         return metadataService.findDataSetById(dataSetId);
     }
 
-    @GetMapping("/version/{dataSetId}/dimensions")
+    @GetMapping("/versions/{dataSetId}/dimensions")
     @CrossOrigin
     public List<DimensionMetadata> listDimensionsForDataSet(@PathVariable String dataSetId) throws DataSetNotFoundException {
         return metadataService.listDimensionsForDataSet(dataSetId);
     }
 
-    @GetMapping("/version/{dataSetId}/dimensions/{dimensionId}")
+    @GetMapping("/versions/{dataSetId}/dimensions/{dimensionId}")
     @CrossOrigin
     public DimensionMetadata findDimensionById(@PathVariable String dataSetId, @PathVariable String dimensionId,
                                                @RequestParam(name = "view", defaultValue = "list") String view)

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/controller/MetadataController.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/controller/MetadataController.java
@@ -20,9 +20,9 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.annotation.RequestScope;
-import uk.co.onsdigital.discovery.metadata.api.dto.DataSet;
-import uk.co.onsdigital.discovery.metadata.api.dto.DimensionMetadata;
-import uk.co.onsdigital.discovery.metadata.api.dto.ResultPage;
+import uk.co.onsdigital.discovery.metadata.api.legacy.dto.DataSet;
+import uk.co.onsdigital.discovery.metadata.api.legacy.dto.DimensionMetadata;
+import uk.co.onsdigital.discovery.metadata.api.legacy.dto.ResultPage;
 import uk.co.onsdigital.discovery.metadata.api.exception.DataSetNotFoundException;
 import uk.co.onsdigital.discovery.metadata.api.exception.DimensionNotFoundException;
 import uk.co.onsdigital.discovery.metadata.api.service.DimensionViewType;
@@ -57,26 +57,26 @@ public class MetadataController {
         return true;
     }
 
-    @GetMapping("/datasets")
+    @GetMapping("/versions")
     @CrossOrigin
     public ResultPage<DataSet> listAvailableDataSets(Pageable pageable) {
         // Ensure pageNumber and pageSize are both at least 1
         return metadataService.listAvailableDataSets(max(pageable.getPageNumber(), 1), max(pageable.getPageSize(), 1));
     }
 
-    @GetMapping("/datasets/{dataSetId}")
+    @GetMapping("/version/{dataSetId}")
     @CrossOrigin
     public DataSet findDataSetById(@PathVariable String dataSetId) throws DataSetNotFoundException {
         return metadataService.findDataSetById(dataSetId);
     }
 
-    @GetMapping("/datasets/{dataSetId}/dimensions")
+    @GetMapping("/version/{dataSetId}/dimensions")
     @CrossOrigin
     public List<DimensionMetadata> listDimensionsForDataSet(@PathVariable String dataSetId) throws DataSetNotFoundException {
         return metadataService.listDimensionsForDataSet(dataSetId);
     }
 
-    @GetMapping("/datasets/{dataSetId}/dimensions/{dimensionId}")
+    @GetMapping("/version/{dataSetId}/dimensions/{dimensionId}")
     @CrossOrigin
     public DimensionMetadata findDimensionById(@PathVariable String dataSetId, @PathVariable String dimensionId,
                                                @RequestParam(name = "view", defaultValue = "list") String view)

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/legacy/dto/DataSet.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/legacy/dto/DataSet.java
@@ -1,4 +1,4 @@
-package uk.co.onsdigital.discovery.metadata.api.dto;
+package uk.co.onsdigital.discovery.metadata.api.legacy.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonRawValue;

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/legacy/dto/DimensionMetadata.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/legacy/dto/DimensionMetadata.java
@@ -1,4 +1,4 @@
-package uk.co.onsdigital.discovery.metadata.api.dto;
+package uk.co.onsdigital.discovery.metadata.api.legacy.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/legacy/dto/DimensionOption.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/legacy/dto/DimensionOption.java
@@ -1,4 +1,4 @@
-package uk.co.onsdigital.discovery.metadata.api.dto;
+package uk.co.onsdigital.discovery.metadata.api.legacy.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/legacy/dto/ResultPage.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/legacy/dto/ResultPage.java
@@ -1,4 +1,4 @@
-package uk.co.onsdigital.discovery.metadata.api.dto;
+package uk.co.onsdigital.discovery.metadata.api.legacy.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import uk.co.onsdigital.discovery.metadata.api.service.UrlBuilder;
+import uk.co.onsdigital.discovery.metadata.api.service.LegacyUrlBuilder;
 
 import java.util.List;
 
@@ -17,9 +17,9 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ResultPage<T> {
     private final Page<T> page;
-    private final UrlBuilder.PageUrlTemplate pageUrlTemplate;
+    private final LegacyUrlBuilder.PageUrlTemplate pageUrlTemplate;
 
-    public ResultPage(UrlBuilder.PageUrlTemplate pageUrlTemplate, List<T> content, long total, int pageNumber, int pageSize) {
+    public ResultPage(LegacyUrlBuilder.PageUrlTemplate pageUrlTemplate, List<T> content, long total, int pageNumber, int pageSize) {
         this.pageUrlTemplate = pageUrlTemplate;
         Pageable pageable = new PageRequest(pageNumber-1, pageSize);
         this.page = new PageImpl<>(content, pageable, total);

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/DimensionViewType.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/DimensionViewType.java
@@ -1,11 +1,10 @@
 package uk.co.onsdigital.discovery.metadata.api.service;
 
-import uk.co.onsdigital.discovery.metadata.api.dto.DimensionOption;
+import uk.co.onsdigital.discovery.metadata.api.legacy.dto.DimensionOption;
 import uk.co.onsdigital.discovery.model.DimensionValue;
 import uk.co.onsdigital.discovery.model.HierarchyEntry;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/LegacyUrlBuilder.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/LegacyUrlBuilder.java
@@ -26,8 +26,8 @@ public class LegacyUrlBuilder {
 
         pageTemplate = new UriTemplate(baseUrl + "/versions?page={page}&size={size}");
         dataSetTemplate = new UriTemplate(baseUrl + "/version/{dataSetId}");
-        dimensionsTemplate = new UriTemplate(baseUrl + "/version/{dataSetId}/dimensions");
-        dimensionTemplate = new UriTemplate(baseUrl + "/version/{dataSetId}/dimensions/{dimensionId}");
+        dimensionsTemplate = new UriTemplate(baseUrl + "/versions/{dataSetId}/dimensions");
+        dimensionTemplate = new UriTemplate(baseUrl + "/versions/{dataSetId}/dimensions/{dimensionId}");
         hierarchyTemplate = new UriTemplate(baseUrl + "/hierarchies/{hierarchyId}");
     }
 

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/LegacyUrlBuilder.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/LegacyUrlBuilder.java
@@ -10,7 +10,7 @@ import static java.util.Objects.requireNonNull;
  * Specialised URL builder service to centralise construction of external URLs.
  */
 @Service
-public class UrlBuilder {
+public class LegacyUrlBuilder {
     static final int MAX_PAGE_SIZE = 1000;
 
     private final String baseUrl;
@@ -21,13 +21,13 @@ public class UrlBuilder {
     private final UriTemplate dimensionTemplate;
     private final UriTemplate hierarchyTemplate;
 
-    UrlBuilder(@Value("#{systemEnvironment['BASE_URL'] ?: 'http://localhost:20099'}") String baseUrl) {
+    LegacyUrlBuilder(@Value("#{systemEnvironment['BASE_URL'] ?: 'http://localhost:20099'}") String baseUrl) {
         this.baseUrl = requireNonNull(baseUrl);
 
-        pageTemplate = new UriTemplate(baseUrl + "/datasets?page={page}&size={size}");
-        dataSetTemplate = new UriTemplate(baseUrl + "/datasets/{dataSetId}");
-        dimensionsTemplate = new UriTemplate(baseUrl + "/datasets/{dataSetId}/dimensions");
-        dimensionTemplate = new UriTemplate(baseUrl + "/datasets/{dataSetId}/dimensions/{dimensionId}");
+        pageTemplate = new UriTemplate(baseUrl + "/versions?page={page}&size={size}");
+        dataSetTemplate = new UriTemplate(baseUrl + "/version/{dataSetId}");
+        dimensionsTemplate = new UriTemplate(baseUrl + "/version/{dataSetId}/dimensions");
+        dimensionTemplate = new UriTemplate(baseUrl + "/version/{dataSetId}/dimensions/{dimensionId}");
         hierarchyTemplate = new UriTemplate(baseUrl + "/hierarchies/{hierarchyId}");
     }
 

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/MetadataService.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/MetadataService.java
@@ -1,8 +1,8 @@
 package uk.co.onsdigital.discovery.metadata.api.service;
 
-import uk.co.onsdigital.discovery.metadata.api.dto.DataSet;
-import uk.co.onsdigital.discovery.metadata.api.dto.DimensionMetadata;
-import uk.co.onsdigital.discovery.metadata.api.dto.ResultPage;
+import uk.co.onsdigital.discovery.metadata.api.legacy.dto.DataSet;
+import uk.co.onsdigital.discovery.metadata.api.legacy.dto.DimensionMetadata;
+import uk.co.onsdigital.discovery.metadata.api.legacy.dto.ResultPage;
 import uk.co.onsdigital.discovery.metadata.api.exception.DataSetNotFoundException;
 import uk.co.onsdigital.discovery.metadata.api.exception.DimensionNotFoundException;
 

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/MetadataServiceImpl.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/MetadataServiceImpl.java
@@ -6,10 +6,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import uk.co.onsdigital.discovery.metadata.api.dao.MetadataDao;
-import uk.co.onsdigital.discovery.metadata.api.dto.DataSet;
-import uk.co.onsdigital.discovery.metadata.api.dto.DimensionMetadata;
-import uk.co.onsdigital.discovery.metadata.api.dto.DimensionOption;
-import uk.co.onsdigital.discovery.metadata.api.dto.ResultPage;
+import uk.co.onsdigital.discovery.metadata.api.legacy.dto.DataSet;
+import uk.co.onsdigital.discovery.metadata.api.legacy.dto.DimensionMetadata;
+import uk.co.onsdigital.discovery.metadata.api.legacy.dto.DimensionOption;
+import uk.co.onsdigital.discovery.metadata.api.legacy.dto.ResultPage;
 import uk.co.onsdigital.discovery.metadata.api.exception.DataSetNotFoundException;
 import uk.co.onsdigital.discovery.metadata.api.exception.DimensionNotFoundException;
 import uk.co.onsdigital.discovery.model.Dimension;
@@ -32,13 +32,13 @@ public class MetadataServiceImpl implements MetadataService {
     private static final Logger logger = LoggerFactory.getLogger(MetadataServiceImpl.class);
 
     private final MetadataDao metadataDao;
-    private final UrlBuilder urlBuilder;
+    private final LegacyUrlBuilder legacyUrlBuilder;
 
-    MetadataServiceImpl(MetadataDao metadataDao, UrlBuilder urlBuilder) {
-        logger.info("Initialising metadata service. Base URL: {}", urlBuilder);
+    MetadataServiceImpl(MetadataDao metadataDao, LegacyUrlBuilder legacyUrlBuilder) {
+        logger.info("Initialising metadata service. Base URL: {}", legacyUrlBuilder);
 
         this.metadataDao = metadataDao;
-        this.urlBuilder = urlBuilder;
+        this.legacyUrlBuilder = legacyUrlBuilder;
     }
 
     @Transactional(readOnly = true)
@@ -51,7 +51,7 @@ public class MetadataServiceImpl implements MetadataService {
             resultDataSets.add(convertDataSet(dbDataSet, false));
         }
 
-        return new ResultPage<>(urlBuilder.datasetsPage(pageSize), resultDataSets, totalDataSets, pageNumber, pageSize);
+        return new ResultPage<>(legacyUrlBuilder.datasetsPage(pageSize), resultDataSets, totalDataSets, pageNumber, pageSize);
     }
 
     @Transactional(readOnly = true)
@@ -104,8 +104,8 @@ public class MetadataServiceImpl implements MetadataService {
         dataSet.setTitle(dbDataSet.getTitle());
         dataSet.setS3URL(dbDataSet.getS3URL());
         dataSet.setMetadata(dbDataSet.getMetadata());
-        dataSet.setUrl(urlBuilder.dataset(dataSet.getId()));
-        dataSet.setDimensionsUrl(urlBuilder.dimensions(dataSet.getId()));
+        dataSet.setUrl(legacyUrlBuilder.dataset(dataSet.getId()));
+        dataSet.setDimensionsUrl(legacyUrlBuilder.dimensions(dataSet.getId()));
 
         if (includeDimensions) {
             final List<DimensionMetadata> dimensions = metadataDao.findDimensionsForDataSet(dataSet.getId()).stream()
@@ -130,7 +130,7 @@ public class MetadataServiceImpl implements MetadataService {
 
         result.setId(dimension.getName());
         result.setName(dimension.getName());
-        result.setUrl(urlBuilder.dimension(dataSetId, dimension.getName()));
+        result.setUrl(legacyUrlBuilder.dimension(dataSetId, dimension.getName()));
         result.setHierarchical(hierarchy != null);
         result.setType(hierarchy == null ? "standard" : hierarchy.getType());
         result.setOptions(viewType.convertValues(dimension.getValues()));
@@ -144,7 +144,7 @@ public class MetadataServiceImpl implements MetadataService {
         dimension.setName(hierarchy.getName());
         dimension.setType(hierarchy.getType());
         dimension.setHierarchical(true);
-        dimension.setUrl(urlBuilder.hierarchy(hierarchy.getId()));
+        dimension.setUrl(legacyUrlBuilder.hierarchy(hierarchy.getId()));
 
         return dimension;
     }

--- a/src/test/java/uk/co/onsdigital/discovery/metadata/api/service/DimensionViewTypeTest.java
+++ b/src/test/java/uk/co/onsdigital/discovery/metadata/api/service/DimensionViewTypeTest.java
@@ -1,7 +1,7 @@
 package uk.co.onsdigital.discovery.metadata.api.service;
 
 import org.testng.annotations.Test;
-import uk.co.onsdigital.discovery.metadata.api.dto.DimensionOption;
+import uk.co.onsdigital.discovery.metadata.api.legacy.dto.DimensionOption;
 import uk.co.onsdigital.discovery.model.*;
 
 import java.util.ArrayList;

--- a/src/test/java/uk/co/onsdigital/discovery/metadata/api/service/LegacyUrlBuilderTest.java
+++ b/src/test/java/uk/co/onsdigital/discovery/metadata/api/service/LegacyUrlBuilderTest.java
@@ -5,59 +5,59 @@ import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class UrlBuilderTest {
+public class LegacyUrlBuilderTest {
     private static final String BASE_URL = "http://example.com:1234/test";
 
-    private UrlBuilder urlBuilder;
+    private LegacyUrlBuilder legacyUrlBuilder;
 
     @BeforeMethod
     public void createUrlBuilder() {
-        urlBuilder = new UrlBuilder(BASE_URL);
+        legacyUrlBuilder = new LegacyUrlBuilder(BASE_URL);
     }
 
     @Test
     public void shouldConstructCorrectPageLinks() {
-        assertThat(urlBuilder.datasetsPage(5).build(4)).isEqualTo(BASE_URL + "/datasets?page=4&size=5");
+        assertThat(legacyUrlBuilder.datasetsPage(5).build(4)).isEqualTo(BASE_URL + "/versions?page=4&size=5");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void shouldRejectPageSizeOfZero() {
-        urlBuilder.datasetsPage(0);
+        legacyUrlBuilder.datasetsPage(0);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void shouldRejectNegativePageSize() {
-        urlBuilder.datasetsPage(-1);
+        legacyUrlBuilder.datasetsPage(-1);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void shouldRejectPageSizeTooLarge() {
-        urlBuilder.datasetsPage(UrlBuilder.MAX_PAGE_SIZE + 1);
+        legacyUrlBuilder.datasetsPage(LegacyUrlBuilder.MAX_PAGE_SIZE + 1);
     }
 
     @Test
     public void shouldConstructCorrectDataSetLinks() {
-        assertThat(urlBuilder.dataset("test")).isEqualTo(BASE_URL + "/datasets/test");
+        assertThat(legacyUrlBuilder.dataset("test")).isEqualTo(BASE_URL + "/version/test");
     }
 
     @Test
     public void shouldConstructCorrectDimensionsLinks() {
-        assertThat(urlBuilder.dimensions("test")).isEqualTo(BASE_URL + "/datasets/test/dimensions");
+        assertThat(legacyUrlBuilder.dimensions("test")).isEqualTo(BASE_URL + "/version/test/dimensions");
     }
 
     @Test
     public void shouldConstructCorrectDimensionLinks() {
-        assertThat(urlBuilder.dimension("test", "testDimension")).isEqualTo(BASE_URL + "/datasets/test/dimensions/testDimension");
+        assertThat(legacyUrlBuilder.dimension("test", "testDimension")).isEqualTo(BASE_URL + "/version/test/dimensions/testDimension");
     }
 
     @Test
     public void shouldHandleUnicodeDimensionNames() {
         // Dataset IDs are UUIDs so will always be ASCII, but dimension IDs might not be. NB: assume UTF-8 encoding.
-        assertThat(urlBuilder.dimension("test", "café")).isEqualTo(BASE_URL + "/datasets/test/dimensions/caf%C3%A9");
+        assertThat(legacyUrlBuilder.dimension("test", "café")).isEqualTo(BASE_URL + "/version/test/dimensions/caf%C3%A9");
     }
 
     @Test
     public void shouldConstructCorrectHierarchyLinks() {
-        assertThat(urlBuilder.hierarchy("testHierarchy")).isEqualTo(BASE_URL + "/hierarchies/testHierarchy");
+        assertThat(legacyUrlBuilder.hierarchy("testHierarchy")).isEqualTo(BASE_URL + "/hierarchies/testHierarchy");
     }
 }

--- a/src/test/java/uk/co/onsdigital/discovery/metadata/api/service/LegacyUrlBuilderTest.java
+++ b/src/test/java/uk/co/onsdigital/discovery/metadata/api/service/LegacyUrlBuilderTest.java
@@ -37,23 +37,23 @@ public class LegacyUrlBuilderTest {
 
     @Test
     public void shouldConstructCorrectDataSetLinks() {
-        assertThat(legacyUrlBuilder.dataset("test")).isEqualTo(BASE_URL + "/version/test");
+        assertThat(legacyUrlBuilder.dataset("test")).isEqualTo(BASE_URL + "/versions/test");
     }
 
     @Test
     public void shouldConstructCorrectDimensionsLinks() {
-        assertThat(legacyUrlBuilder.dimensions("test")).isEqualTo(BASE_URL + "/version/test/dimensions");
+        assertThat(legacyUrlBuilder.dimensions("test")).isEqualTo(BASE_URL + "/versions/test/dimensions");
     }
 
     @Test
     public void shouldConstructCorrectDimensionLinks() {
-        assertThat(legacyUrlBuilder.dimension("test", "testDimension")).isEqualTo(BASE_URL + "/version/test/dimensions/testDimension");
+        assertThat(legacyUrlBuilder.dimension("test", "testDimension")).isEqualTo(BASE_URL + "/versions/test/dimensions/testDimension");
     }
 
     @Test
     public void shouldHandleUnicodeDimensionNames() {
         // Dataset IDs are UUIDs so will always be ASCII, but dimension IDs might not be. NB: assume UTF-8 encoding.
-        assertThat(legacyUrlBuilder.dimension("test", "café")).isEqualTo(BASE_URL + "/version/test/dimensions/caf%C3%A9");
+        assertThat(legacyUrlBuilder.dimension("test", "café")).isEqualTo(BASE_URL + "/versions/test/dimensions/caf%C3%A9");
     }
 
     @Test

--- a/src/test/java/uk/co/onsdigital/discovery/metadata/api/service/MetadataServiceTest.java
+++ b/src/test/java/uk/co/onsdigital/discovery/metadata/api/service/MetadataServiceTest.java
@@ -74,7 +74,7 @@ public class MetadataServiceTest {
         List<DataSet> result = metadataService.listAvailableDataSets(1, 5).getItems();
 
         assertThat(result).hasSize(1);
-        assertThat(result.iterator().next().getUrl()).isEqualTo(BASE_URL + "/version/" + DATASET_ID);
+        assertThat(result.iterator().next().getUrl()).isEqualTo(BASE_URL + "/versions/" + DATASET_ID);
     }
 
     @Test
@@ -153,14 +153,14 @@ public class MetadataServiceTest {
         // Check that dimension options are properly created
         assertThat(dimension1.getName()).isEqualTo("dim1");
         assertThat(dimension1.getType()).isEqualTo("standard");
-        assertThat(dimension1.getUrl()).isEqualTo(BASE_URL + "/version/" + DATASET_ID + "/dimensions/dim1");
+        assertThat(dimension1.getUrl()).isEqualTo(BASE_URL + "/versions/" + DATASET_ID + "/dimensions/dim1");
         assertThat(dimension1.isHierarchical()).isFalse();
         assertThat(dimension1.getOptions()).containsOnly(new DimensionOption(null, "val1"), new DimensionOption(null, "val2"));
 
         assertThat(dimension2.getName()).isEqualTo("dim2");
         assertThat(dimension2.getType()).isEqualTo("test");
-        assertThat(dimension2.getUrl()).isEqualTo(BASE_URL + "/version/" + DATASET_ID + "/dimensions/dim2");
-        assertThat(dimension2.isHierarchical()).isTrue();
+        assertThat(dimension2.getUrl()).isEqualTo(BASE_URL + "/versions/" + DATASET_ID + "/dimensions/dim2");
+        assertThat(dimension2.isHierarchical()).isTrue();t
         assertThat(dimension2.getOptions()).containsOnly(new DimensionOption(null, entry.getCode(), entry.getName()));
     }
 

--- a/src/test/java/uk/co/onsdigital/discovery/metadata/api/service/MetadataServiceTest.java
+++ b/src/test/java/uk/co/onsdigital/discovery/metadata/api/service/MetadataServiceTest.java
@@ -5,10 +5,10 @@ import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import uk.co.onsdigital.discovery.metadata.api.dao.MetadataDao;
-import uk.co.onsdigital.discovery.metadata.api.dto.DataSet;
-import uk.co.onsdigital.discovery.metadata.api.dto.DimensionMetadata;
-import uk.co.onsdigital.discovery.metadata.api.dto.DimensionOption;
-import uk.co.onsdigital.discovery.metadata.api.dto.ResultPage;
+import uk.co.onsdigital.discovery.metadata.api.legacy.dto.DataSet;
+import uk.co.onsdigital.discovery.metadata.api.legacy.dto.DimensionMetadata;
+import uk.co.onsdigital.discovery.metadata.api.legacy.dto.DimensionOption;
+import uk.co.onsdigital.discovery.metadata.api.legacy.dto.ResultPage;
 import uk.co.onsdigital.discovery.metadata.api.exception.DataSetNotFoundException;
 import uk.co.onsdigital.discovery.metadata.api.exception.DimensionNotFoundException;
 import uk.co.onsdigital.discovery.model.Dimension;
@@ -42,7 +42,7 @@ public class MetadataServiceTest {
     @BeforeMethod
     public void createMetadataService() {
         MockitoAnnotations.initMocks(this);
-        metadataService = new MetadataServiceImpl(mockDao, new UrlBuilder(BASE_URL));
+        metadataService = new MetadataServiceImpl(mockDao, new LegacyUrlBuilder(BASE_URL));
     }
 
     @Test
@@ -74,7 +74,7 @@ public class MetadataServiceTest {
         List<DataSet> result = metadataService.listAvailableDataSets(1, 5).getItems();
 
         assertThat(result).hasSize(1);
-        assertThat(result.iterator().next().getUrl()).isEqualTo(BASE_URL + "/datasets/" + DATASET_ID);
+        assertThat(result.iterator().next().getUrl()).isEqualTo(BASE_URL + "/version/" + DATASET_ID);
     }
 
     @Test
@@ -153,13 +153,13 @@ public class MetadataServiceTest {
         // Check that dimension options are properly created
         assertThat(dimension1.getName()).isEqualTo("dim1");
         assertThat(dimension1.getType()).isEqualTo("standard");
-        assertThat(dimension1.getUrl()).isEqualTo(BASE_URL + "/datasets/" + DATASET_ID + "/dimensions/dim1");
+        assertThat(dimension1.getUrl()).isEqualTo(BASE_URL + "/version/" + DATASET_ID + "/dimensions/dim1");
         assertThat(dimension1.isHierarchical()).isFalse();
         assertThat(dimension1.getOptions()).containsOnly(new DimensionOption(null, "val1"), new DimensionOption(null, "val2"));
 
         assertThat(dimension2.getName()).isEqualTo("dim2");
         assertThat(dimension2.getType()).isEqualTo("test");
-        assertThat(dimension2.getUrl()).isEqualTo(BASE_URL + "/datasets/" + DATASET_ID + "/dimensions/dim2");
+        assertThat(dimension2.getUrl()).isEqualTo(BASE_URL + "/version/" + DATASET_ID + "/dimensions/dim2");
         assertThat(dimension2.isHierarchical()).isTrue();
         assertThat(dimension2.getOptions()).containsOnly(new DimensionOption(null, entry.getCode(), entry.getName()));
     }


### PR DESCRIPTION
### What

Changed the `/datasets` endpoint to `/versions` and `/datasets/x` to `/version/x`. Moving legacy API calls to alternative endpoints to pave way for new URI endpoints.

### How to review

- Make sure `mvn test`s all pass
- Run the app and hit the `/versions` endpoint and the sub `/version` endpoints.
- Check the codes

### Who can review

Any backender.