### PR TITLE
New uri endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,24 +29,29 @@
         </plugins>
     </build>
 
-    <repositories>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
-    </repositories>
+    <!--<repositories>-->
+        <!--<repository>-->
+            <!--<id>jitpack.io</id>-->
+            <!--<url>https://jitpack.io</url>-->
+        <!--</repository>-->
+    <!--</repositories>-->
 
     <dependencies>
-        <dependency>
-            <groupId>com.github.ONSdigital</groupId>
-            <artifactId>dp-dd-backend-model</artifactId>
-            <version>develop-SNAPSHOT</version>
-        </dependency>
         <!--<dependency>-->
-            <!--<groupId>uk.co.onsdigital.discovery</groupId>-->
-            <!--<artifactId>dd-model</artifactId>-->
-            <!--<version>1.0.0-SNAPSHOT</version>-->
+            <!--<groupId>com.github.ONSdigital</groupId>-->
+            <!--<artifactId>dp-dd-backend-model</artifactId>-->
+            <!--<version>develop-SNAPSHOT</version>-->
         <!--</dependency>-->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.5</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.co.onsdigital.discovery</groupId>
+            <artifactId>dd-model</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>eclipselink</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,29 +29,29 @@
         </plugins>
     </build>
 
-    <!--<repositories>-->
-        <!--<repository>-->
-            <!--<id>jitpack.io</id>-->
-            <!--<url>https://jitpack.io</url>-->
-        <!--</repository>-->
-    <!--</repositories>-->
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
 
     <dependencies>
-        <!--<dependency>-->
-            <!--<groupId>com.github.ONSdigital</groupId>-->
-            <!--<artifactId>dp-dd-backend-model</artifactId>-->
-            <!--<version>develop-SNAPSHOT</version>-->
-        <!--</dependency>-->
+        <dependency>
+            <groupId>com.github.ONSdigital</groupId>
+            <artifactId>dp-dd-backend-model</artifactId>
+            <version>develop-SNAPSHOT</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.5</version>
         </dependency>
-        <dependency>
-            <groupId>uk.co.onsdigital.discovery</groupId>
-            <artifactId>dd-model</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
-        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>uk.co.onsdigital.discovery</groupId>-->
+            <!--<artifactId>dd-model</artifactId>-->
+            <!--<version>1.0.0-SNAPSHOT</version>-->
+        <!--</dependency>-->
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>eclipselink</artifactId>

--- a/scripts/codedeploy/application-start.sh
+++ b/scripts/codedeploy/application-start.sh
@@ -5,8 +5,8 @@ CONFIG_BUCKET=
 ECR_REPOSITORY_URI=
 GIT_COMMIT=
 
-INSTANCE=$(curl -s http://instance-data/latest/meta-data/instance-id)
-CONFIG=$(aws --region $AWS_REGION ec2 describe-tags --filters "Name=resource-id,Values=$INSTANCE" "Name=key,Values=Configuration" --output text | awk '{print $5}')
+INSTANCE=$(curl -s http://instance-data/latest/meta-data/instance-datasetId)
+CONFIG=$(aws --region $AWS_REGION ec2 describe-tags --filters "Name=resource-datasetId,Values=$INSTANCE" "Name=key,Values=Configuration" --output text | awk '{print $5}')
 
 if [[ $DEPLOYMENT_GROUP_NAME =~ [a-z]+-publishing ]]; then
   CONFIG_DIRECTORY=publishing

--- a/scripts/codedeploy/application-start.sh
+++ b/scripts/codedeploy/application-start.sh
@@ -5,8 +5,8 @@ CONFIG_BUCKET=
 ECR_REPOSITORY_URI=
 GIT_COMMIT=
 
-INSTANCE=$(curl -s http://instance-data/latest/meta-data/instance-datasetId)
-CONFIG=$(aws --region $AWS_REGION ec2 describe-tags --filters "Name=resource-datasetId,Values=$INSTANCE" "Name=key,Values=Configuration" --output text | awk '{print $5}')
+INSTANCE=$(curl -s http://instance-data/latest/meta-data/instance-id)
+CONFIG=$(aws --region $AWS_REGION ec2 describe-tags --filters "Name=resource-id,Values=$INSTANCE" "Name=key,Values=Configuration" --output text | awk '{print $5}')
 
 if [[ $DEPLOYMENT_GROUP_NAME =~ [a-z]+-publishing ]]; then
   CONFIG_DIRECTORY=publishing

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/controller/MetadataController.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/controller/MetadataController.java
@@ -20,9 +20,10 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.annotation.RequestScope;
-import uk.co.onsdigital.discovery.metadata.api.legacy.dto.DataSet;
-import uk.co.onsdigital.discovery.metadata.api.legacy.dto.DimensionMetadata;
-import uk.co.onsdigital.discovery.metadata.api.legacy.dto.ResultPage;
+import uk.co.onsdigital.discovery.metadata.api.dto.DataResourceResult;
+import uk.co.onsdigital.discovery.metadata.api.dto.legacy.DataSet;
+import uk.co.onsdigital.discovery.metadata.api.dto.common.DimensionMetadata;
+import uk.co.onsdigital.discovery.metadata.api.dto.legacy.ResultPage;
 import uk.co.onsdigital.discovery.metadata.api.exception.DataSetNotFoundException;
 import uk.co.onsdigital.discovery.metadata.api.exception.DimensionNotFoundException;
 import uk.co.onsdigital.discovery.metadata.api.service.DimensionViewType;
@@ -57,32 +58,73 @@ public class MetadataController {
         return true;
     }
 
+    @GetMapping("/datasets")
+    @CrossOrigin
+    public ResultPage<DataResourceResult> listAvailableVersions(Pageable pageable) {
+        // Ensure pageNumber and pageSize are both at least 1
+        return metadataService.listAvailableDataResources(max(pageable.getPageNumber(), 1), max(pageable.getPageSize(), 1));
+    }
+
     @GetMapping("/versions")
     @CrossOrigin
     public ResultPage<DataSet> listAvailableDataSets(Pageable pageable) {
         // Ensure pageNumber and pageSize are both at least 1
-        return metadataService.listAvailableDataSets(max(pageable.getPageNumber(), 1), max(pageable.getPageSize(), 1));
+        return metadataService.listAvailableVersions(max(pageable.getPageNumber(), 1), max(pageable.getPageSize(), 1));
     }
+
 
     @GetMapping("/versions/{dataSetId}")
     @CrossOrigin
-    public DataSet findDataSetById(@PathVariable String dataSetId) throws DataSetNotFoundException {
-        return metadataService.findDataSetById(dataSetId);
+    public DataSet findDataSetByUuid(@PathVariable String dataSetId) throws DataSetNotFoundException {
+        return metadataService.findDataSetByUuid(dataSetId);
+    }
+
+
+    @GetMapping("/datasets/{dataSetId}")
+    @CrossOrigin
+    public DataResourceResult findDataResource(@PathVariable String dataSetId) throws DataSetNotFoundException {
+        return metadataService.findDataResource(dataSetId);
+    }
+
+    @GetMapping("/datasets/{dataSetId}/editions/{edition}/versions/{version}")
+    @CrossOrigin
+    public DataSet findDataSetByEditionAndVersion(@PathVariable String dataSetId, @PathVariable String edition,
+                                                  @PathVariable int version)
+            throws DataSetNotFoundException {
+        return metadataService.findDataSetByEditionAndVersion(dataSetId, edition, version);
     }
 
     @GetMapping("/versions/{dataSetId}/dimensions")
     @CrossOrigin
-    public List<DimensionMetadata> listDimensionsForDataSet(@PathVariable String dataSetId) throws DataSetNotFoundException {
-        return metadataService.listDimensionsForDataSet(dataSetId);
+    public List<DimensionMetadata> listDimensionsForDataSetUuid(@PathVariable String dataSetId) throws DataSetNotFoundException {
+        return metadataService.listDimensionsForDataSetUuid(dataSetId);
+    }
+
+    @GetMapping("/datasets/{dataSetId}/editions/{edition}/versions/{version}/dimensions")
+    @CrossOrigin
+    public List<DimensionMetadata> listDimensionsforDataSetEditionVersion(@PathVariable String dataSetId, @PathVariable String edition,
+                                                                          @PathVariable int version)
+            throws DataSetNotFoundException {
+        return metadataService.listDimensionsForDataSetEditionVersion(dataSetId, edition, version);
     }
 
     @GetMapping("/versions/{dataSetId}/dimensions/{dimensionId}")
     @CrossOrigin
-    public DimensionMetadata findDimensionById(@PathVariable String dataSetId, @PathVariable String dimensionId,
+    public DimensionMetadata findDimensionByIdWithDatasetUuid(@PathVariable String dataSetId, @PathVariable String dimensionId,
                                                @RequestParam(name = "view", defaultValue = "list") String view)
             throws DataSetNotFoundException, DimensionNotFoundException {
         final DimensionViewType viewType = DimensionViewType.valueOf(view.toUpperCase());
-        return metadataService.findDimensionById(dataSetId, dimensionId, viewType);
+        return metadataService.findDimensionByIdWithDatasetUuid(dataSetId, dimensionId, viewType);
+    }
+
+    @GetMapping("/datasets/{dataSetId}/editions/{edition}/versions/{version}/dimensions/{dimensionId}")
+    @CrossOrigin
+    public DimensionMetadata findDimensionByIdWithEditionVersion(@PathVariable String dataSetId, @PathVariable String edition,
+                                                                 @PathVariable int version, @PathVariable String dimensionId,
+                                               @RequestParam(name = "view", defaultValue = "list") String view)
+            throws DataSetNotFoundException, DimensionNotFoundException {
+        final DimensionViewType viewType = DimensionViewType.valueOf(view.toUpperCase());
+        return metadataService.findDimensionByIdWithEditionVersion(dataSetId, edition, version, dimensionId, viewType);
     }
 
     @GetMapping("/hierarchies")

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dao/MetadataDao.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dao/MetadataDao.java
@@ -1,10 +1,7 @@
 package uk.co.onsdigital.discovery.metadata.api.dao;
 
 import uk.co.onsdigital.discovery.metadata.api.exception.DataSetNotFoundException;
-import uk.co.onsdigital.discovery.model.Dimension;
-import uk.co.onsdigital.discovery.model.DimensionalDataSet;
-import uk.co.onsdigital.discovery.model.Hierarchy;
-import uk.co.onsdigital.discovery.model.HierarchyEntry;
+import uk.co.onsdigital.discovery.model.*;
 
 import java.util.List;
 
@@ -20,6 +17,8 @@ public interface MetadataDao {
      */
     long countDataSets();
 
+    long countDataResources();
+
     /**
      * Find a page of available datasets present in the database.
      *
@@ -27,24 +26,54 @@ public interface MetadataDao {
      * @param pageSize the number of results to include in a page.
      * @return a list of available datasets for the given pageNumber and pageSize.
      */
-    List<DimensionalDataSet> findDataSetsPage(int pageNumber, int pageSize);
+    List<DimensionalDataSet> findLegacyDataSetsPage(int pageNumber, int pageSize);
 
     /**
-     * Find a particular dataset by id.
+     * Find a page of available dataresources (datasets on the front-end) present in the database.
+     *
+     * @param pageNumber the number of the page to get, starting from 1.
+     * @param pageSize the number of results to include in a page.
+     * @return a list of available dataresources for the given pageNumber and pageSize.
+     */
+    List<DataResource> findDataResourcesPage(int pageNumber, int pageSize);
+
+    DataResource findDataResource(String dataResourceId);
+
+    /**
+     * Find a particular dataset by UUID.
      * @param dataSetId the dataset id.
      * @return the matching dataset if found.
      * @throws DataSetNotFoundException if the dataset does not exist.
      */
-    DimensionalDataSet findDataSetById(String dataSetId) throws DataSetNotFoundException;
+    DimensionalDataSet findDataSetByUuid(String dataSetId) throws DataSetNotFoundException;
 
     /**
-     * Load the dimensions for a given dataset.
+     * Find a particular dataset by edition and version.
+     * @param edition the edition of the dimensional dataset.
+     * @param version the version of the dimensional dataset.
+     * @return the matching dataset if found.
+     * @throws DataSetNotFoundException if the dataset does not exist.
+     */
+    DimensionalDataSet findDataSetByEditionAndVersion(String dataResourceId, String edition, int version) throws DataSetNotFoundException;
+
+    /**
+     * Load the dimensions for a given dataset based on UUID.
      *
      * @param dataSetId the id of the dataset to load the dimensions for.
      * @return the dimensions defined in the given dataset.
      * @throws DataSetNotFoundException if the dataset does not exist.
      */
     List<Dimension> findDimensionsForDataSet(String dataSetId) throws DataSetNotFoundException;
+
+    /**
+     * Load the dimensions for a given dataset based on edition and version.
+     *
+     * @param edition the edition of the dimensional dataset.
+     * @param version the version of the dimensional dataset.
+     * @return the dimensions defined in the given dataset.
+     * @throws DataSetNotFoundException if the dataset does not exist.
+     */
+    List<Dimension> findDimensionsForDataSet(String dataResourceId, String edition, int version) throws DataSetNotFoundException;
 
     /**
      * List all hierarchies defined in the database.

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dao/MetadataDao.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dao/MetadataDao.java
@@ -1,5 +1,6 @@
 package uk.co.onsdigital.discovery.metadata.api.dao;
 
+import uk.co.onsdigital.discovery.metadata.api.exception.DataResourceNotFoundExcecption;
 import uk.co.onsdigital.discovery.metadata.api.exception.DataSetNotFoundException;
 import uk.co.onsdigital.discovery.model.*;
 
@@ -37,7 +38,13 @@ public interface MetadataDao {
      */
     List<DataResource> findDataResourcesPage(int pageNumber, int pageSize);
 
-    DataResource findDataResource(String dataResourceId);
+    /**
+     * Find a particular dataresource by its id and list all the dimensional data set editions and versions it has.
+     * @param dataResourceId the dataresource id.
+     * @return the matching dataset if found.
+     * @throws DataResourceNotFoundExcecption if the dataset does not exist.
+     */
+    DataResource findDataResource(String dataResourceId) throws DataResourceNotFoundExcecption;
 
     /**
      * Find a particular dataset by UUID.

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dao/MetadataDaoImpl.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dao/MetadataDaoImpl.java
@@ -71,9 +71,6 @@ public class MetadataDaoImpl implements MetadataDao {
                             .setParameter(DimensionalDataSet.EDITION_PARAM, edition)
                             .setParameter(DimensionalDataSet.VERSION_PARAM, version)
                             .getSingleResult();
-            if (dataSet == null) {
-                throw new DataSetNotFoundException("No such dataset: " + edition);
-            }
             return dataSet;
         } catch (NoResultException e) {
             throw new DataSetNotFoundException("No such dataset: " + edition);

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dao/MetadataDaoImpl.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dao/MetadataDaoImpl.java
@@ -64,16 +64,21 @@ public class MetadataDaoImpl implements MetadataDao {
 
     @Override
     public DimensionalDataSet findDataSetByEditionAndVersion(String dataResourceId, String edition, int version) throws DataSetNotFoundException {
-        final DimensionalDataSet dataSet =
-                entityManager.createNamedQuery(DimensionalDataSet.FIND_BY_EDITION_VERSION, DimensionalDataSet.class)
-                        .setParameter(DimensionalDataSet.DATA_RESOURCE_PARAM, dataResourceId)
-                        .setParameter(DimensionalDataSet.EDITION_PARAM, edition)
-                        .setParameter(DimensionalDataSet.VERSION_PARAM, version)
-                        .getSingleResult();
-        if (dataSet == null) {
+        try {
+            final DimensionalDataSet dataSet =
+                    entityManager.createNamedQuery(DimensionalDataSet.FIND_BY_EDITION_VERSION, DimensionalDataSet.class)
+                            .setParameter(DimensionalDataSet.DATA_RESOURCE_PARAM, dataResourceId)
+                            .setParameter(DimensionalDataSet.EDITION_PARAM, edition)
+                            .setParameter(DimensionalDataSet.VERSION_PARAM, version)
+                            .getSingleResult();
+            if (dataSet == null) {
+                throw new DataSetNotFoundException("No such dataset: " + edition);
+            }
+            return dataSet;
+        } catch (NoResultException e) {
             throw new DataSetNotFoundException("No such dataset: " + edition);
         }
-        return dataSet;    }
+    }
 
     @Override
     public List<Dimension> findDimensionsForDataSet(String dataSetId) throws DataSetNotFoundException {

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dao/MetadataDaoImpl.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dao/MetadataDaoImpl.java
@@ -1,6 +1,7 @@
 package uk.co.onsdigital.discovery.metadata.api.dao;
 
 import org.springframework.stereotype.Repository;
+import uk.co.onsdigital.discovery.metadata.api.exception.DataResourceNotFoundExcecption;
 import uk.co.onsdigital.discovery.metadata.api.exception.DataSetNotFoundException;
 import uk.co.onsdigital.discovery.model.*;
 
@@ -44,10 +45,10 @@ public class MetadataDaoImpl implements MetadataDao {
                 .setFirstResult(firstPageOffset).setMaxResults(pageSize).getResultList();
     }
 
-    public DataResource findDataResource(String dataResourceId) {
+    public DataResource findDataResource(String dataResourceId) throws DataResourceNotFoundExcecption {
         final DataResource dataResource = entityManager.find(DataResource.class, dataResourceId);
         if (dataResource == null) {
-            throw new DataSetNotFoundException("No such dataset: " + dataResourceId);
+            throw new DataResourceNotFoundExcecption("No such dataResource: " + dataResourceId);
         }
         return dataResource;
     }

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/DataResourceResult.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/DataResourceResult.java
@@ -1,0 +1,51 @@
+package uk.co.onsdigital.discovery.metadata.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRawValue;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents metadata about a particular dataset.
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class DataResourceResult {
+
+    private String datasetId;
+    private Latest latest;
+    private List<Edition> editions;
+
+    public Latest getLatest() {
+        return latest;
+    }
+
+    public void setLatest(Latest latest) {
+        this.latest = latest;
+    }
+
+    public List<Edition> getEditions() {
+        return editions;
+    }
+
+    public void setEditions(List<Edition> editions) {
+        this.editions = editions;
+    }
+
+    public String getDatasetId() {
+        return datasetId;
+    }
+
+    public void setDatasetId(String datasetId) {
+        this.datasetId = datasetId;
+    }
+
+    @Override
+    public String toString() {
+        return "DataResourceResult{" +
+                "datasetId='" + datasetId + '\'' +
+                ", latest='" + latest + '\'' +
+                ", editions=" + editions +
+                '}';
+    }
+}

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/DimensionalDataSetResult.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/DimensionalDataSetResult.java
@@ -1,0 +1,53 @@
+package uk.co.onsdigital.discovery.metadata.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRawValue;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class DimensionalDataSetResult extends uk.co.onsdigital.discovery.metadata.api.dto.legacy.DataSet {
+    private String edition;
+    private String version;
+    private String datasetId;
+
+    public String getEdition() {
+        return edition;
+    }
+
+    public void setEdition(String edition) {
+        this.edition = edition;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    @Override @JsonRawValue
+    public String getMetadata() {
+        return metadata;
+    }
+
+    @Override
+    public String toString() {
+        return "DataSet{" +
+                "id='" + id + '\'' +
+                ", title='" + title + '\'' +
+                ", s3URL='" + s3URL + '\'' +
+                ", url='" + url + '\'' +
+                ", edition=" + edition + "\'" +
+                ", version=" + version + "\'" +
+                ", metadata=" + metadata +
+                '}';
+    }
+
+    public String getDatasetId() {
+        return datasetId;
+    }
+
+    public void setDatasetId(String datasetId) {
+        this.datasetId = datasetId;
+    }
+}

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/Edition.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/Edition.java
@@ -31,4 +31,13 @@ public class Edition {
     public void setVersions(List<Integer> versions) {
         this.versions = versions;
     }
+
+    @Override
+    public String toString() {
+        return "Edition{" +
+                "id='" + id + '\'' +
+                ", label='" + label + '\'' +
+                ", versions='" + versions +
+                '}';
+    }
 }

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/Edition.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/Edition.java
@@ -1,0 +1,34 @@
+package uk.co.onsdigital.discovery.metadata.api.dto;
+
+import java.util.List;
+
+public class Edition {
+
+    private String label;
+    private String id;
+    private List<Integer> versions;
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public List<Integer> getVersions() {
+        return versions;
+    }
+
+    public void setVersions(List<Integer> versions) {
+        this.versions = versions;
+    }
+}

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/Latest.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/Latest.java
@@ -1,0 +1,54 @@
+package uk.co.onsdigital.discovery.metadata.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRawValue;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class Latest {
+    private String edition;
+    private String version;
+    private String metadata;
+    private String title;
+    private String url;
+
+    public String getEdition() {
+        return edition;
+    }
+
+    public void setEdition(String edition) {
+        this.edition = edition;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    @JsonRawValue
+    public String getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(String metadata) {
+        this.metadata = metadata;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/Latest.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/Latest.java
@@ -51,4 +51,15 @@ public class Latest {
     public void setUrl(String url) {
         this.url = url;
     }
+
+    @Override
+    public String toString() {
+        return "Latest {" +
+                "edition='" + edition + '\'' +
+                ", version='" + version + '\'' +
+                ", title='" + title + '\'' +
+                ", url='" + url + '\'' +
+                ", metadata=" + metadata +
+                '}';
+    }
 }

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/ResultPage.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/ResultPage.java
@@ -1,0 +1,79 @@
+package uk.co.onsdigital.discovery.metadata.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import uk.co.onsdigital.discovery.metadata.api.service.LegacyUrlBuilder;
+
+import java.util.List;
+
+/**
+ * Specialistion of Spring's {@link PageImpl} to convert the JSON output to match the Stub API field naming.
+ */
+@JsonPropertyOrder({"items", "first", "prev", "next", "last"})
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ResultPage<T> {
+    private final Page<T> page;
+    private final LegacyUrlBuilder.PageUrlTemplate pageUrlTemplate;
+
+    public ResultPage(LegacyUrlBuilder.PageUrlTemplate pageUrlTemplate, List<T> content, long total, int pageNumber, int pageSize) {
+        this.pageUrlTemplate = pageUrlTemplate;
+        Pageable pageable = new PageRequest(pageNumber-1, pageSize);
+        this.page = new PageImpl<>(content, pageable, total);
+    }
+
+    public List<T> getItems() {
+        return page.getContent();
+    }
+
+    public long getTotal() {
+        return page.getTotalElements();
+    }
+
+    public int getCount() {
+        return page.getNumberOfElements();
+    }
+
+    public int getPage() {
+        // Spring pages are 0-based, which seems a bit unintuitive
+        return page.getNumber() + 1;
+    }
+
+    public int getTotalPages() {
+        return (int) (getTotal() / getItemsPerPage());
+    }
+
+    public int getItemsPerPage() {
+        return page.getSize();
+    }
+
+    public long getStartIndex() {
+        return page.getNumber() * page.getSize();
+    }
+
+    public String getPrev() {
+        return getPage() > 1 ? pageUrlTemplate.build(getPage() - 1) : null;
+    }
+
+    public String getNext() {
+        return getPage() < getTotalPages() ? pageUrlTemplate.build(getPage() + 1) : null;
+    }
+
+    public String getFirst() {
+        return pageUrlTemplate.build(1);
+    }
+
+    public String getLast() {
+        return pageUrlTemplate.build(getTotalPages());
+    }
+
+    @Override
+    public String toString() {
+        return "ResultPage{" +
+                "page=" + page +
+                '}';
+    }
+}

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/common/DimensionMetadata.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/common/DimensionMetadata.java
@@ -1,4 +1,4 @@
-package uk.co.onsdigital.discovery.metadata.api.legacy.dto;
+package uk.co.onsdigital.discovery.metadata.api.dto.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/common/DimensionOption.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/common/DimensionOption.java
@@ -1,4 +1,4 @@
-package uk.co.onsdigital.discovery.metadata.api.legacy.dto;
+package uk.co.onsdigital.discovery.metadata.api.dto.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/legacy/DataSet.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/legacy/DataSet.java
@@ -1,7 +1,8 @@
-package uk.co.onsdigital.discovery.metadata.api.legacy.dto;
+package uk.co.onsdigital.discovery.metadata.api.dto.legacy;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonRawValue;
+import uk.co.onsdigital.discovery.metadata.api.dto.common.DimensionMetadata;
 
 import java.util.Collections;
 import java.util.List;
@@ -12,13 +13,13 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class DataSet {
 
-    private String id;
-    private String s3URL;
-    private String title;
-    private String url;
-    private String metadata;
-    private List<DimensionMetadata> dimensions = Collections.emptyList();
-    private String dimensionsUrl;
+    protected String id;
+    protected String s3URL;
+    protected String title;
+    protected String url;
+    protected String metadata;
+    protected List<DimensionMetadata> dimensions = Collections.emptyList();
+    protected String dimensionsUrl;
 
     public String getId() {
         return id;

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/legacy/ResultPage.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/legacy/ResultPage.java
@@ -1,4 +1,4 @@
-package uk.co.onsdigital.discovery.metadata.api.legacy.dto;
+package uk.co.onsdigital.discovery.metadata.api.dto.legacy;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/exception/DataResourceNotFoundExcecption.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/exception/DataResourceNotFoundExcecption.java
@@ -1,0 +1,10 @@
+package uk.co.onsdigital.discovery.metadata.api.exception;
+
+/**
+ * Indicates that a dataset was not found.
+ */
+public class DataResourceNotFoundExcecption extends NotFoundException {
+    public DataResourceNotFoundExcecption(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/DimensionViewType.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/DimensionViewType.java
@@ -1,6 +1,6 @@
 package uk.co.onsdigital.discovery.metadata.api.service;
 
-import uk.co.onsdigital.discovery.metadata.api.legacy.dto.DimensionOption;
+import uk.co.onsdigital.discovery.metadata.api.dto.common.DimensionOption;
 import uk.co.onsdigital.discovery.model.DimensionValue;
 import uk.co.onsdigital.discovery.model.HierarchyEntry;
 

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/MetadataService.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/MetadataService.java
@@ -10,16 +10,16 @@ import uk.co.onsdigital.discovery.metadata.api.exception.DimensionNotFoundExcept
 import java.util.List;
 
 /**
- * The metadata service provides an API for retrieving available datasets and querying them for available dimensions.
+ * The metadata service provides an API for retrieving available dataresources and datasets and querying them for available dimensions.
  */
 public interface MetadataService {
 
     /**
-     * Return a page of datasets defined in the database.
+     * Return a page of dataresources defined in the database.
      *
      * @param pageNumber the number of the page to return, starting at 1.
      * @param pageSize the number of datasets to include in each page.
-     * @return all available datasets.
+     * @return all available dataresources.
      */
     ResultPage<DataResourceResult> listAvailableDataResources(int pageNumber, int pageSize);
 
@@ -41,6 +41,13 @@ public interface MetadataService {
      */
     DataSet findDataSetByUuid(String dataSetUuid) throws DataSetNotFoundException;
 
+    /**
+     * Find a particular dataresource by its ID and display its available editions and versions.
+     *
+     * @param dataResourceId the id of the dataresource to retrieve.
+     * @return the matching dataset.
+     * @throws DataSetNotFoundException if the dataset does not exist.
+     */
     DataResourceResult findDataResource(String dataResourceId) throws DataSetNotFoundException;
 
     /**

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/MetadataService.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/MetadataService.java
@@ -1,8 +1,9 @@
 package uk.co.onsdigital.discovery.metadata.api.service;
 
-import uk.co.onsdigital.discovery.metadata.api.legacy.dto.DataSet;
-import uk.co.onsdigital.discovery.metadata.api.legacy.dto.DimensionMetadata;
-import uk.co.onsdigital.discovery.metadata.api.legacy.dto.ResultPage;
+import uk.co.onsdigital.discovery.metadata.api.dto.DataResourceResult;
+import uk.co.onsdigital.discovery.metadata.api.dto.legacy.DataSet;
+import uk.co.onsdigital.discovery.metadata.api.dto.common.DimensionMetadata;
+import uk.co.onsdigital.discovery.metadata.api.dto.legacy.ResultPage;
 import uk.co.onsdigital.discovery.metadata.api.exception.DataSetNotFoundException;
 import uk.co.onsdigital.discovery.metadata.api.exception.DimensionNotFoundException;
 
@@ -20,37 +21,83 @@ public interface MetadataService {
      * @param pageSize the number of datasets to include in each page.
      * @return all available datasets.
      */
-    ResultPage<DataSet> listAvailableDataSets(int pageNumber, int pageSize);
+    ResultPage<DataResourceResult> listAvailableDataResources(int pageNumber, int pageSize);
 
     /**
-     * Find a particular dataset by id.
+     * Return a page of datasets defined in the database. This is the **legacy** version.
      *
-     * @param dataSetId the id of the dataset to retrieve.
+     * @param pageNumber the number of the page to return, starting at 1.
+     * @param pageSize the number of datasets to include in each page.
+     * @return all available datasets.
+     */
+    ResultPage<DataSet> listAvailableVersions(int pageNumber, int pageSize);
+
+    /**
+     * Find a particular dataset by UUID.
+     *
+     * @param dataSetUuid the id of the dataset to retrieve.
      * @return the matching dataset.
      * @throws DataSetNotFoundException if the dataset does not exist.
      */
-    DataSet findDataSetById(String dataSetId) throws DataSetNotFoundException;
+    DataSet findDataSetByUuid(String dataSetUuid) throws DataSetNotFoundException;
+
+    DataResourceResult findDataResource(String dataResourceId) throws DataSetNotFoundException;
 
     /**
-     * List the available dimensions for a particular dataset.
+     * Find a particular dataset by UUID.
      *
-     * @param dataSetId the id of the dataset to list dimensions for.
+     * @param edition the major_label of dimensional_dataset.
+     * @param version the version of a dimensional_dataset.
+     * @return the matching dataset.
+     * @throws DataSetNotFoundException if the dataset does not exist.
+     */
+    DataSet findDataSetByEditionAndVersion(String dataResourceId, String edition, int version) throws DataSetNotFoundException;
+
+    /**
+     * List the available dimensions for a particular dataset using its uuid.
+     *
+     * @param datasetUuid the uuid of the dataset version to list dimensions for.
      * @return the dimensions defined by that dataset.
      */
-    List<DimensionMetadata> listDimensionsForDataSet(String dataSetId) throws DataSetNotFoundException;
+    List<DimensionMetadata> listDimensionsForDataSetUuid(String datasetUuid) throws DataSetNotFoundException;
 
     /**
-     * Find the definition of a dimension defined on a particular dataset. The particular options for the dimension will
-     * be filtered to only contain those that actually occur in the dataset.
+     * List the available dimensions for a particular dataset using its edition and version.
      *
-     * @param dataSetId the id of the dataset.
+     * @param dataResourceId the dataResourced id
+     * @param edition the major_label of dimensional_dataset.
+     * @param version the version of a dimensional_dataset.
+     * @return the dimensions defined by that dataset.
+     */
+    List<DimensionMetadata> listDimensionsForDataSetEditionVersion(String dataResourceId, String edition, int version) throws DataSetNotFoundException;
+
+    /**
+     * Find the definition of a dimension defined on a particular dataset based on a dimensional dataset UUID.
+     * The particular options for the dimension will be filtered to only contain those that actually occur in the dataset.
+     *
+     * @param dataSetUuid the id of the dataset.
      * @param dimensionId the id of the dimension to query.
      * @param viewType the type of view to use for the dimension options.
      * @return the given dimension definition for the given dataset.
      * @throws DimensionNotFoundException if the dimension does not exist in this dataset.
      * @throws DataSetNotFoundException if the dataset does not exist.
      */
-    DimensionMetadata findDimensionById(String dataSetId, String dimensionId, DimensionViewType viewType) throws DataSetNotFoundException,
+    DimensionMetadata findDimensionByIdWithDatasetUuid(String dataSetUuid, String dimensionId, DimensionViewType viewType) throws DataSetNotFoundException,
+            DimensionNotFoundException;
+
+    /**
+     * Find the definition of a dimension defined on a particular dataset based on a dimensional dataset edition and version.
+     * The particular options for the dimension will be filtered to only contain those that actually occur in the dataset.
+     *
+     * @param edition the major_label of dimensional_dataset.
+     * @param version the version of a dimensional_dataset.
+     * @param dimensionId the id of the dimension to query.
+     * @param viewType the type of view to use for the dimension options.
+     * @return the given dimension definition for the given dataset.
+     * @throws DimensionNotFoundException if the dimension does not exist in this dataset.
+     * @throws DataSetNotFoundException if the dataset does not exist.
+     */
+    DimensionMetadata findDimensionByIdWithEditionVersion(String datasetId, String edition, int version, String dimensionId, DimensionViewType viewType) throws DataSetNotFoundException,
             DimensionNotFoundException;
 
     /**

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/MetadataServiceImpl.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/MetadataServiceImpl.java
@@ -1,28 +1,29 @@
 package uk.co.onsdigital.discovery.metadata.api.service;
 
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import uk.co.onsdigital.discovery.metadata.api.dao.MetadataDao;
-import uk.co.onsdigital.discovery.metadata.api.legacy.dto.DataSet;
-import uk.co.onsdigital.discovery.metadata.api.legacy.dto.DimensionMetadata;
-import uk.co.onsdigital.discovery.metadata.api.legacy.dto.DimensionOption;
-import uk.co.onsdigital.discovery.metadata.api.legacy.dto.ResultPage;
+import uk.co.onsdigital.discovery.metadata.api.dto.DataResourceResult;
+import uk.co.onsdigital.discovery.metadata.api.dto.DimensionalDataSetResult;
+import uk.co.onsdigital.discovery.metadata.api.dto.Edition;
+import uk.co.onsdigital.discovery.metadata.api.dto.Latest;
+import uk.co.onsdigital.discovery.metadata.api.dto.common.DimensionMetadata;
+import uk.co.onsdigital.discovery.metadata.api.dto.common.DimensionOption;
+import uk.co.onsdigital.discovery.metadata.api.dto.legacy.DataSet;
+import uk.co.onsdigital.discovery.metadata.api.dto.legacy.ResultPage;
 import uk.co.onsdigital.discovery.metadata.api.exception.DataSetNotFoundException;
 import uk.co.onsdigital.discovery.metadata.api.exception.DimensionNotFoundException;
-import uk.co.onsdigital.discovery.model.Dimension;
-import uk.co.onsdigital.discovery.model.DimensionValue;
-import uk.co.onsdigital.discovery.model.DimensionalDataSet;
-import uk.co.onsdigital.discovery.model.Hierarchy;
-import uk.co.onsdigital.discovery.model.HierarchyEntry;
+import uk.co.onsdigital.discovery.model.*;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 
 /**
  * Implementation of the {@link MetadataService}.
@@ -33,42 +34,79 @@ public class MetadataServiceImpl implements MetadataService {
 
     private final MetadataDao metadataDao;
     private final LegacyUrlBuilder legacyUrlBuilder;
+    private final UrlBuilder urlBuilder;
 
-    MetadataServiceImpl(MetadataDao metadataDao, LegacyUrlBuilder legacyUrlBuilder) {
+    MetadataServiceImpl(MetadataDao metadataDao, UrlBuilder urlBuilder, LegacyUrlBuilder legacyUrlBuilder) {
         logger.info("Initialising metadata service. Base URL: {}", legacyUrlBuilder);
 
         this.metadataDao = metadataDao;
         this.legacyUrlBuilder = legacyUrlBuilder;
+        this.urlBuilder = urlBuilder;
     }
 
     @Transactional(readOnly = true)
-    public ResultPage<DataSet> listAvailableDataSets(int pageNumber, int pageSize) {
-        final long totalDataSets = metadataDao.countDataSets();
-        final List<DimensionalDataSet> dbDataSets = metadataDao.findDataSetsPage(pageNumber, pageSize);
-        final List<DataSet> resultDataSets = new ArrayList<>(dbDataSets.size());
+    public ResultPage<DataResourceResult> listAvailableDataResources(int pageNumber, int pageSize) {
+        final long totalDataSets = metadataDao.countDataResources();
+        final List<DataResource> dbDataSets = metadataDao.findDataResourcesPage(pageNumber, pageSize);
+        final List<DataResourceResult> resultDataSets = new ArrayList<>(dbDataSets.size());
 
-        for (DimensionalDataSet dbDataSet : dbDataSets) {
-            resultDataSets.add(convertDataSet(dbDataSet, false));
+        for(DataResource dataResource: dbDataSets) {
+            resultDataSets.add(convertDataResource(dataResource));
         }
 
         return new ResultPage<>(legacyUrlBuilder.datasetsPage(pageSize), resultDataSets, totalDataSets, pageNumber, pageSize);
     }
 
     @Transactional(readOnly = true)
-    public DataSet findDataSetById(String dataSetId) throws DataSetNotFoundException {
-        return convertDataSet(metadataDao.findDataSetById(dataSetId), true);
+    public ResultPage<DataSet> listAvailableVersions(int pageNumber, int pageSize) {
+        final long totalDataSets = metadataDao.countDataSets();
+        final List<DimensionalDataSet> dbDataSets = metadataDao.findLegacyDataSetsPage(pageNumber, pageSize);
+        final List<DataSet> resultDataSets = new ArrayList<>(dbDataSets.size());
+
+        for (DimensionalDataSet dbDataSet : dbDataSets) {
+            resultDataSets.add(legacyConvertDataSet(dbDataSet, false));
+        }
+
+        return new ResultPage<>(legacyUrlBuilder.datasetsPage(pageSize), resultDataSets, totalDataSets, pageNumber, pageSize);
     }
 
     @Transactional(readOnly = true)
-    public List<DimensionMetadata> listDimensionsForDataSet(String dataSetId) throws DataSetNotFoundException {
-        return metadataDao.findDimensionsForDataSet(dataSetId).stream()
-                .map(d -> convertDimension(dataSetId, d, DimensionViewType.LIST))
+    public DataSet findDataSetByUuid(String dataSetUuid) throws DataSetNotFoundException {
+        return legacyConvertDataSet(metadataDao.findDataSetByUuid(dataSetUuid), true);
+    }
+
+    public DataResourceResult findDataResource(String dataResourceId) throws DataSetNotFoundException {
+        return convertDataResource(metadataDao.findDataResource(dataResourceId));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public DataSet findDataSetByEditionAndVersion(String dataResourceId, String edition, int version) throws DataSetNotFoundException {
+        return convertDataSet(metadataDao.findDataSetByEditionAndVersion(dataResourceId, edition, version), true);
+    }
+
+    @Transactional(readOnly = true)
+    public List<DimensionMetadata> listDimensionsForDataSetUuid(String datasetUuid) throws DataSetNotFoundException {
+        return metadataDao.findDimensionsForDataSet(datasetUuid).stream()
+                .map(d -> legacyConvertDimension(datasetUuid, d, DimensionViewType.LIST))
+                .collect(toList());
+    }
+
+    @Override
+    public List<DimensionMetadata> listDimensionsForDataSetEditionVersion(String dataResourceId, String edition, int version) throws DataSetNotFoundException {
+        return metadataDao.findDimensionsForDataSet(dataResourceId, edition, version).stream()
+                .map(d -> convertDimension(dataResourceId, edition, version, d, DimensionViewType.LIST))
                 .collect(toList());
     }
 
     @Transactional(readOnly = true)
-    public DimensionMetadata findDimensionById(String dataSetId, String dimensionId, DimensionViewType viewType) throws DataSetNotFoundException, DimensionNotFoundException {
-        return convertDimension(dataSetId, findByName(metadataDao.findDimensionsForDataSet(dataSetId), dimensionId), viewType);
+    public DimensionMetadata findDimensionByIdWithDatasetUuid(String dataSetUuid, String dimensionId, DimensionViewType viewType) throws DataSetNotFoundException, DimensionNotFoundException {
+        return legacyConvertDimension(dataSetUuid, findByName(metadataDao.findDimensionsForDataSet(dataSetUuid), dimensionId), viewType);
+    }
+
+    @Override
+    public DimensionMetadata findDimensionByIdWithEditionVersion(String dataSetId, String edition, int version, String dimensionId, DimensionViewType viewType) throws DataSetNotFoundException, DimensionNotFoundException {
+        return convertDimension(dataSetId, edition, version, findByName(metadataDao.findDimensionsForDataSet(dataSetId, edition, version), dimensionId), viewType);
     }
 
     @Override
@@ -98,23 +136,84 @@ public class MetadataServiceImpl implements MetadataService {
      * @param includeDimensions whether to include the dimensions in the output.
      * @return the {@link DataSet} model populated with the metadata about the dataset.
      */
-    private DataSet convertDataSet(final DimensionalDataSet dbDataSet, final boolean includeDimensions) {
+    private DataSet legacyConvertDataSet(final DimensionalDataSet dbDataSet, final boolean includeDimensions) {
         final DataSet dataSet = new DataSet();
         dataSet.setId(dbDataSet.getId().toString());
         dataSet.setTitle(dbDataSet.getTitle());
         dataSet.setS3URL(dbDataSet.getS3URL());
-        dataSet.setMetadata(dbDataSet.getMetadata());
+        dataSet.setMetadata(StringUtils.defaultIfEmpty(dbDataSet.getMetadata(), "{}"));
         dataSet.setUrl(legacyUrlBuilder.dataset(dataSet.getId()));
         dataSet.setDimensionsUrl(legacyUrlBuilder.dimensions(dataSet.getId()));
 
         if (includeDimensions) {
             final List<DimensionMetadata> dimensions = metadataDao.findDimensionsForDataSet(dataSet.getId()).stream()
-                    .map(d -> convertDimension(dataSet.getId(), d, DimensionViewType.NONE))
+                    .map(d -> legacyConvertDimension(dataSet.getId(), d, DimensionViewType.NONE))
                     .collect(toList());
             dataSet.setDimensions(dimensions);
         }
 
         return dataSet;
+    }
+
+    private DimensionalDataSetResult convertDataSet(final DimensionalDataSet dbDataSet, final boolean includeDimensions) {
+        final DimensionalDataSetResult ddSet = new DimensionalDataSetResult();
+        ddSet.setId(dbDataSet.getId().toString());
+        ddSet.setDatasetId(dbDataSet.getDataResource().getId());
+        ddSet.setTitle(dbDataSet.getTitle());
+        ddSet.setS3URL(dbDataSet.getS3URL());
+        String metadata = defaultIfEmpty(dbDataSet.getMetadata(), "{}"); // Preference from frontend to return an empty object over null
+        ddSet.setMetadata(StringUtils.defaultIfEmpty(dbDataSet.getMetadata(), "{}"));
+        ddSet.setVersion(Integer.toString(dbDataSet.getMinorVersion()));
+        ddSet.setEdition(dbDataSet.getMajorLabel());
+        ddSet.setDatasetId(dbDataSet.getDataResource().getId());
+
+        if (includeDimensions) {
+            final List<DimensionMetadata> dimensions = metadataDao.findDimensionsForDataSet(ddSet.getId()).stream()
+                    .map(d -> convertDimension(dbDataSet.getDataResource().getId(), dbDataSet.getMajorLabel(), dbDataSet.getMinorVersion(), d, DimensionViewType.NONE))
+                    .collect(toList());
+            ddSet.setDimensions(dimensions);
+        }
+        ddSet.setUrl(urlBuilder.dimensionalDataSet(ddSet.getDatasetId(), ddSet.getEdition(), dbDataSet.getMinorVersion()));
+        ddSet.setDimensionsUrl(urlBuilder.dimensions(ddSet.getDatasetId(), ddSet.getEdition(), ddSet.getVersion()));
+        return ddSet;
+    }
+
+    private DataResourceResult convertDataResource(final DataResource dataResource) {
+        final DataResourceResult drResult = new DataResourceResult();
+        drResult.setDatasetId(dataResource.getId());
+        final Latest latest = new Latest();
+        final List<DimensionalDataSet> dds = dataResource.getDimensionalDataSets();
+        if (dds.size() == 0) {
+            drResult.setLatest(null);
+            drResult.setEditions(null);
+        } else {
+            final DimensionalDataSet latestDds = dds.get(0); // this will always be the latest as we order by major and minor in the model
+            latest.setMetadata(StringUtils.defaultIfEmpty(latestDds.getMetadata(), "{}"));
+            latest.setEdition(latestDds.getMajorLabel());
+            latest.setVersion(Integer.toString(latestDds.getMinorVersion()));
+            latest.setTitle(latestDds.getTitle());
+            latest.setUrl(urlBuilder.dimensionalDataSet(drResult.getDatasetId(), latest.getEdition(), latestDds.getMinorVersion()));
+            drResult.setLatest(latest);
+            drResult.setEditions(extractEditionAndValuesFromDimensionalDataSets(dds));
+        }
+        return drResult;
+    }
+
+    private List<Edition> extractEditionAndValuesFromDimensionalDataSets(List<DimensionalDataSet> dimensionalDataSets) {
+        HashMap<Integer, Edition> editionMap = new LinkedHashMap<>();
+        for(DimensionalDataSet dds: dimensionalDataSets) {
+          Edition edition = editionMap.get(dds.getMajorVersion());
+          if (edition == null) {
+              edition = new Edition();
+              edition.setId(Integer.toString(dds.getMajorVersion()));
+              edition.setLabel(dds.getMajorLabel());
+          }
+          List<Integer> versions = ObjectUtils.defaultIfNull(edition.getVersions(), new LinkedList<>());
+          versions.add(dds.getMinorVersion());
+          edition.setVersions(versions);
+          editionMap.put(dds.getMajorVersion(), edition);
+        }
+        return new LinkedList<>(editionMap.values());
     }
 
     private static Dimension findByName(Collection<Dimension> dimensions, String name) throws DimensionNotFoundException {
@@ -124,13 +223,21 @@ public class MetadataServiceImpl implements MetadataService {
         return dimensions.stream().filter(d -> name.equals(d.getName())).findAny().orElseThrow(() -> new DimensionNotFoundException(name));
     }
 
-    private DimensionMetadata convertDimension(String dataSetId, Dimension dimension, DimensionViewType viewType) {
+    private DimensionMetadata legacyConvertDimension(String dataSetId, Dimension dimension, DimensionViewType viewType) {
+        return setDimensionWithUrl(dimension, viewType, legacyUrlBuilder.dimension(dataSetId, dimension.getName()));
+    }
+
+    private DimensionMetadata convertDimension(String dataResourceId, String edition, int version, Dimension dimension, DimensionViewType viewType) {
+        return setDimensionWithUrl(dimension, viewType, urlBuilder.dimension(dataResourceId, edition, version, dimension.getName()));
+    }
+
+    private DimensionMetadata setDimensionWithUrl(Dimension dimension, DimensionViewType viewType, String url) {
         Hierarchy hierarchy = dimension.getHierarchy();
         DimensionMetadata result = new DimensionMetadata();
 
         result.setId(dimension.getName());
         result.setName(dimension.getName());
-        result.setUrl(legacyUrlBuilder.dimension(dataSetId, dimension.getName()));
+        result.setUrl(url);
         result.setHierarchical(hierarchy != null);
         result.setType(hierarchy == null ? "standard" : hierarchy.getType());
         result.setOptions(viewType.convertValues(dimension.getValues()));

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/UrlBuilder.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/service/UrlBuilder.java
@@ -7,27 +7,29 @@ import org.springframework.web.util.UriTemplate;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Specialised URL builder service to centralise construction of external URLs on the versions path.
+ * Specialised URL builder service to centralise construction of external URLs.
  */
 @Service
-public class LegacyUrlBuilder {
+public class UrlBuilder {
     static final int MAX_PAGE_SIZE = 1000;
 
     private final String baseUrl;
 
     private final UriTemplate pageTemplate;
     private final UriTemplate dataSetTemplate;
+    private final UriTemplate dimensionalDataSetTemplate;
     private final UriTemplate dimensionsTemplate;
     private final UriTemplate dimensionTemplate;
     private final UriTemplate hierarchyTemplate;
 
-    LegacyUrlBuilder(@Value("#{systemEnvironment['BASE_URL'] ?: 'http://localhost:20099'}") String baseUrl) {
+    UrlBuilder(@Value("#{systemEnvironment['BASE_URL'] ?: 'http://localhost:20099'}") String baseUrl) {
         this.baseUrl = requireNonNull(baseUrl);
 
-        pageTemplate = new UriTemplate(baseUrl + "/versions?page={page}&size={size}");
-        dataSetTemplate = new UriTemplate(baseUrl + "/versions/{dataSetId}");
-        dimensionsTemplate = new UriTemplate(baseUrl + "/versions/{dataSetId}/dimensions");
-        dimensionTemplate = new UriTemplate(baseUrl + "/versions/{dataSetId}/dimensions/{dimensionId}");
+        pageTemplate = new UriTemplate(baseUrl + "/datasets?page={page}&size={size}");
+        dataSetTemplate = new UriTemplate(baseUrl + "/datasets/{dataSetId}");
+        dimensionalDataSetTemplate = new UriTemplate(baseUrl + "/datasets/{dataSetId}/editions/{edition}/versions/{version}");
+        dimensionsTemplate = new UriTemplate(baseUrl + "/datasets/{dataSetId}/editions/{edition}/versions/{version}/dimensions");
+        dimensionTemplate = new UriTemplate(baseUrl + "/datasets/{dataSetId}/editions/{edition}/versions/{version}/dimensions/{dimensionId}");
         hierarchyTemplate = new UriTemplate(baseUrl + "/hierarchies/{hierarchyId}");
     }
 
@@ -58,13 +60,25 @@ public class LegacyUrlBuilder {
     }
 
     /**
+     * Constructs a link to a particular dataset.
+     *
+     * @param dataResourceId the id of the dataresource.
+     * @param edition the edition.
+     * @param version the version.
+     * @return an external link to the given dataset.
+     */
+    public String dimensionalDataSet(String dataResourceId, String edition, int version) {
+        return dimensionalDataSetTemplate.expand(dataResourceId, edition, version).toString();
+    }
+
+    /**
      * Constructs a link to the dimensions of a given dataset.
      *
      * @param dataSetId the dataset id.
      * @return an external link to the dimensions page for the dataset.
      */
-    public String dimensions(String dataSetId) {
-        return dimensionsTemplate.expand(dataSetId).toString();
+    public String dimensions(String dataSetId, String edition, String version) {
+        return dimensionsTemplate.expand(dataSetId, edition, version).toString();
     }
 
     /**
@@ -74,8 +88,8 @@ public class LegacyUrlBuilder {
      * @param dimensionId the id of the dimension.
      * @return a link to the given dimension in the given dataset.
      */
-    public String dimension(String dataSetId, String dimensionId) {
-        return dimensionTemplate.expand(dataSetId, dimensionId).toString();
+    public String dimension(String dataSetId, String edition, int version, String dimensionId) {
+        return dimensionTemplate.expand(dataSetId, edition, version, dimensionId).toString();
     }
 
     /**

--- a/src/test/java/uk/co/onsdigital/discovery/metadata/api/dao/MetadataDaoTest.java
+++ b/src/test/java/uk/co/onsdigital/discovery/metadata/api/dao/MetadataDaoTest.java
@@ -5,6 +5,7 @@ import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import uk.co.onsdigital.discovery.metadata.api.exception.DataSetNotFoundException;
+import uk.co.onsdigital.discovery.model.DataResource;
 import uk.co.onsdigital.discovery.model.DimensionalDataSet;
 
 import javax.persistence.EntityManager;
@@ -22,7 +23,10 @@ public class MetadataDaoTest {
     private EntityManager mockEntityManager;
 
     @Mock
-    private TypedQuery<DimensionalDataSet> mockQuery;
+    private TypedQuery<DimensionalDataSet> mockDimensionalDataSetQuery;
+
+    @Mock
+    private TypedQuery<DataResource> mockDataResourceQuery;
 
     private MetadataDao metadataDao;
 
@@ -36,14 +40,28 @@ public class MetadataDaoTest {
     public void shouldReturnAllDataSetsFromDatabase() throws Exception {
         List<DimensionalDataSet> dataSets = asList(new DimensionalDataSet(), new DimensionalDataSet());
 
-        when(mockEntityManager.createNamedQuery("DimensionalDataSet.findAll", DimensionalDataSet.class)).thenReturn(mockQuery);
-        when(mockQuery.setFirstResult(0)).thenReturn(mockQuery);
-        when(mockQuery.setMaxResults(10)).thenReturn(mockQuery);
-        when(mockQuery.getResultList()).thenReturn(dataSets);
+        when(mockEntityManager.createNamedQuery("DimensionalDataSet.findAll", DimensionalDataSet.class)).thenReturn(mockDimensionalDataSetQuery);
+        when(mockDimensionalDataSetQuery.setFirstResult(0)).thenReturn(mockDimensionalDataSetQuery);
+        when(mockDimensionalDataSetQuery.setMaxResults(10)).thenReturn(mockDimensionalDataSetQuery);
+        when(mockDimensionalDataSetQuery.getResultList()).thenReturn(dataSets);
 
         List<DimensionalDataSet> result = metadataDao.findLegacyDataSetsPage(1, 10);
         assertThat(result).isEqualTo(dataSets);
     }
+
+    @Test
+    public void shouldReturnAllDataResourcesFromDatabase() throws Exception {
+        List<DataResource> dataResources = asList(new DataResource());
+
+        when(mockEntityManager.createNamedQuery("DataResource.findAll", DataResource.class)).thenReturn(mockDataResourceQuery);
+        when(mockDataResourceQuery.setFirstResult(0)).thenReturn(mockDataResourceQuery);
+        when(mockDataResourceQuery.setMaxResults(10)).thenReturn(mockDataResourceQuery);
+        when(mockDataResourceQuery.getResultList()).thenReturn(dataResources);
+
+        List<DataResource> result = metadataDao.findDataResourcesPage(1, 10);
+        assertThat(result).isEqualTo(dataResources);
+    }
+
 
     @Test(expectedExceptions = DataSetNotFoundException.class)
     public void shouldFailIfDataSetNotFound() throws Exception {

--- a/src/test/java/uk/co/onsdigital/discovery/metadata/api/dao/MetadataDaoTest.java
+++ b/src/test/java/uk/co/onsdigital/discovery/metadata/api/dao/MetadataDaoTest.java
@@ -41,13 +41,13 @@ public class MetadataDaoTest {
         when(mockQuery.setMaxResults(10)).thenReturn(mockQuery);
         when(mockQuery.getResultList()).thenReturn(dataSets);
 
-        List<DimensionalDataSet> result = metadataDao.findDataSetsPage(1, 10);
+        List<DimensionalDataSet> result = metadataDao.findLegacyDataSetsPage(1, 10);
         assertThat(result).isEqualTo(dataSets);
     }
 
     @Test(expectedExceptions = DataSetNotFoundException.class)
     public void shouldFailIfDataSetNotFound() throws Exception {
-        metadataDao.findDataSetById(UUID.randomUUID().toString());
+        metadataDao.findDataSetByUuid(UUID.randomUUID().toString());
     }
 
     @Test
@@ -57,12 +57,12 @@ public class MetadataDaoTest {
 
         when(mockEntityManager.find(DimensionalDataSet.class, dataSetId)).thenReturn(dataSet);
 
-        final DimensionalDataSet result = metadataDao.findDataSetById(dataSetId.toString());
+        final DimensionalDataSet result = metadataDao.findDataSetByUuid(dataSetId.toString());
         assertThat(result).isEqualTo(dataSet);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void shouldRejectInvalidDataSetIds() throws Exception {
-        metadataDao.findDataSetById("not a uuid");
+        metadataDao.findDataSetByUuid("not a uuid");
     }
 }

--- a/src/test/java/uk/co/onsdigital/discovery/metadata/api/service/DimensionViewTypeTest.java
+++ b/src/test/java/uk/co/onsdigital/discovery/metadata/api/service/DimensionViewTypeTest.java
@@ -1,7 +1,7 @@
 package uk.co.onsdigital.discovery.metadata.api.service;
 
 import org.testng.annotations.Test;
-import uk.co.onsdigital.discovery.metadata.api.legacy.dto.DimensionOption;
+import uk.co.onsdigital.discovery.metadata.api.dto.common.DimensionOption;
 import uk.co.onsdigital.discovery.model.*;
 
 import java.util.ArrayList;

--- a/src/test/java/uk/co/onsdigital/discovery/metadata/api/service/UrlBuilderTest.java
+++ b/src/test/java/uk/co/onsdigital/discovery/metadata/api/service/UrlBuilderTest.java
@@ -1,0 +1,63 @@
+package uk.co.onsdigital.discovery.metadata.api.service;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UrlBuilderTest {
+    private static final String BASE_URL = "http://example.com:1234/test";
+
+    private UrlBuilder urlBuilder;
+
+    @BeforeMethod
+    public void createUrlBuilder() {
+        urlBuilder = new UrlBuilder(BASE_URL);
+    }
+
+    @Test
+    public void shouldConstructCorrectPageLinks() {
+        assertThat(urlBuilder.datasetsPage(5).build(4)).isEqualTo(BASE_URL + "/datasets?page=4&size=5");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldRejectPageSizeOfZero() {
+        urlBuilder.datasetsPage(0);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldRejectNegativePageSize() {
+        urlBuilder.datasetsPage(-1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldRejectPageSizeTooLarge() {
+        urlBuilder.datasetsPage(LegacyUrlBuilder.MAX_PAGE_SIZE + 1);
+    }
+
+    @Test
+    public void shouldConstructCorrectDataResourceLinks() {
+        assertThat(urlBuilder.dataset("test")).isEqualTo(BASE_URL + "/datasets/test");
+    }
+
+    @Test
+    public void shouldConstructCorrectDimensionsLinks() {
+        assertThat(urlBuilder.dimensionalDataSet("test", "2017", 1)).isEqualTo(BASE_URL + "/datasets/test/editions/2017/versions/1");
+    }
+
+    @Test
+    public void shouldConstructCorrectDimensionLinks() {
+        assertThat(urlBuilder.dimension("test", "2017", 1, "testDimension")).isEqualTo(BASE_URL + "/datasets/test/editions/2017/versions/1/dimensions/testDimension");
+    }
+
+    @Test
+    public void shouldHandleUnicodeDimensionNames() {
+        // Dataset IDs are UUIDs so will always be ASCII, but dimension IDs might not be. NB: assume UTF-8 encoding.
+        assertThat(urlBuilder.dimension("test", "2017", 1, "café")).isEqualTo(BASE_URL + "/datasets/test/editions/2017/versions/1/dimensions/caf%C3%A9");
+    }
+
+    @Test
+    public void shouldConstructCorrectHierarchyLinks() {
+        assertThat(urlBuilder.hierarchy("testHierarchy")).isEqualTo(BASE_URL + "/hierarchies/testHierarchy");
+    }
+}


### PR DESCRIPTION
### What

Added new URI paths `/datasets/{datasetsId}/editions/{edition}/version/{version}`. 

There are now 5 new URIs in total:

- `/datasets`
- `/datasets/{dataSetId}`
- `/datasets/{dataSetId}/editions/{edition}/versions/{version}`
- `/datasets/{dataSetId}/editions/{edition}/versions/{version}/dimensions`
- `/datasets/{dataSetId}/editions/{edition}/versions/{version}/dimensions/{dimensionId}`

The results of those URIs will now contain relevant updated information, such as new URI mappings for `url` entries and `edition` with `version` being displayed for dataresources and dimensional datasets.

### How to review

Make sure to run the application with the latest model (pending [this PR](https://github.com/ONSdigital/dp-dd-backend-model/pull/33))

### Who can review

Any back-ender