### PR TITLE
Order dimension options by code before name.

### DIFF
--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/common/DimensionOption.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/dto/common/DimensionOption.java
@@ -86,8 +86,8 @@ public class DimensionOption implements Comparable<DimensionOption> {
     public int compareTo(final DimensionOption that) {
         return ComparisonChain.start()
                 .compare(this.levelType, that.levelType, LevelTypeComparator.INSTANCE)
+                .compare(this.code, that.code, Ordering.from(String.CASE_INSENSITIVE_ORDER).nullsLast())
                 .compare(this.name, that.name, Ordering.from(String.CASE_INSENSITIVE_ORDER).nullsLast())
-                .compare(this.code, that.code, Ordering.natural().nullsLast())
                 .result();
     }
 


### PR DESCRIPTION
### What

Bugfix for UI guys - currently we sort dimension options by level type and then name, which results in a weird ordering for months etc (August, April, ...). The codes more often define the correct order for options, so use that in preference.

### How to review

`mvn clean spring-boot:run` and navigate to some dimensions in the API and check the order is sensible.

### Who can review

Anyone but me.