### PR TITLE
Add in memory cache to hierarchy and dimension related methods. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,11 @@
             <artifactId>spring-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjweaver</artifactId>
         </dependency>

--- a/src/test/java/uk/co/onsdigital/discovery/metadata/api/controller/MetadataControllerTest.java
+++ b/src/test/java/uk/co/onsdigital/discovery/metadata/api/controller/MetadataControllerTest.java
@@ -1,0 +1,88 @@
+package uk.co.onsdigital.discovery.metadata.api.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.testng.annotations.Test;
+import uk.co.onsdigital.discovery.metadata.api.service.DimensionViewType;
+import uk.co.onsdigital.discovery.metadata.api.service.MetadataService;
+
+import static org.mockito.Mockito.*;
+
+public class MetadataControllerTest extends AbstractTestNGSpringContextTests {
+
+    @Autowired MetadataController metadataController;
+    @Autowired MetadataService metadataService;
+
+    @Configuration
+    @EnableCaching
+    static class Config {
+        @Bean
+        public MetadataController getMetadataController() {
+            return new MetadataController();
+        }
+
+        @Bean
+        public MetadataService getMetadataService() {
+            return mock(MetadataService.class);
+        }
+
+        @Bean
+        public CacheManager getCacheManager() {
+            return new ConcurrentMapCacheManager("hierarchies", "dimensions");
+        }
+    }
+
+    @Test
+    public void getHierarchyShouldCacheResponse() {
+
+        // Given a hierarchy ID we want to get.
+        String hierarchyId = "hierarchy1";
+
+        // When we call getHierarchy multiple times
+        metadataController.getHierarchy(hierarchyId);
+        metadataController.getHierarchy(hierarchyId);
+
+        // Then the metadata service is called only once as it is cached after the first call.
+        verify(metadataService, times(1)).getHierarchy(hierarchyId);
+    }
+
+    @Test
+    public void findDimensionByIdWithDatasetUuidShouldCacheResponse() {
+
+        // Given a dimension ID we want to get.
+        String datasetId = "datasetId";
+        String dimensionId = "dimensionId";
+        String view = "HIERARCHY";
+
+        // When we call findDimensionByIdWithDatasetUuid multiple times
+        metadataController.findDimensionByIdWithDatasetUuid(datasetId, dimensionId, view);
+        metadataController.findDimensionByIdWithDatasetUuid(datasetId, dimensionId, view);
+
+        // Then the metadata service is called only once as it is cached after the first call.
+        verify(metadataService, times(1)).findDimensionByIdWithDatasetUuid(datasetId, dimensionId, DimensionViewType.HIERARCHY);
+    }
+
+    @Test
+    public void findDimensionByIdWithEditionVersionShouldCacheResponse() {
+
+        // Given a dimension ID we want to get.
+        String datasetId = "datasetId";
+        String edition = "edition";
+        String dimensionId = "dimensionId";
+        int version = 3;
+        String view = "HIERARCHY";
+
+        // When we call findDimensionByIdWithEditionVersion multiple times
+        metadataController.findDimensionByIdWithEditionVersion(datasetId, edition, version, dimensionId, view);
+        metadataController.findDimensionByIdWithEditionVersion(datasetId, edition, version, dimensionId, view);
+
+        // Then the metadata service is called only once as it is cached after the first call.
+        verify(metadataService, times(1))
+                .findDimensionByIdWithEditionVersion(datasetId, edition, version, dimensionId, DimensionViewType.HIERARCHY);
+    }
+}


### PR DESCRIPTION
### What

Added in memory cache to hierarchy and dimension related methods. 
Note that there is no eviction of cache entries so there is only so many dimensions and hierarchies we can support before running out of memory. It was decided for alpha that this was sufficient. If there are issues when in the develop environment we will either have to increase memory, evict cache entries, or store the cache out of process.

### How to review

mvn test  - ensure the tests pass
Check that the response time is greatly reduced for the second request of a dimension or hierarchy

### Who can review

Anyone with Java / Spring knowledge.
