### PR TITLE
Provide cache control headers for hierarchy / dimension endpoints 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ following environment variables to configure the system:
  * `DB_URL`: The database JDBC URL. Defaults to `jdbc:postgresql://localhost:5432/data_discovery`.
  * `DB_DRIVER`: The JDBC driver to load. Defaults to `org.postgresql.Driver`.
  * `INCLUDE_GEO_DIMENSIONS`: Whether to expose geographical hierarchies as dimensions. Defaults to `false`.
+ * `DEFAULT_CACHE_TIME_MINUTES`: The default max-age value to use in cache control headers.
 
 ## Contributing
 

--- a/src/main/java/uk/co/onsdigital/discovery/metadata/api/controller/MetadataController.java
+++ b/src/main/java/uk/co/onsdigital/discovery/metadata/api/controller/MetadataController.java
@@ -3,6 +3,7 @@ package uk.co.onsdigital.discovery.metadata.api.controller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -14,7 +15,9 @@ import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -45,6 +48,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static java.lang.Math.max;
 import static java.util.Arrays.asList;
@@ -60,8 +64,15 @@ import static java.util.Arrays.asList;
 public class MetadataController {
     private static final Logger logger = LoggerFactory.getLogger(MetadataController.class);
 
+    private final MetadataService metadataService;
+    private final int defaultCacheTimeMinutes;
+
     @Autowired
-    private MetadataService metadataService;
+    public MetadataController(MetadataService metadataService,
+                              @Value("${default.cache.time.minutes}") int defaultCacheTimeMinutes) {
+        this.metadataService = metadataService;
+        this.defaultCacheTimeMinutes = defaultCacheTimeMinutes;
+    }
 
     public static void main(String...args) {
         SpringApplication.run(MetadataController.class, args);
@@ -96,7 +107,6 @@ public class MetadataController {
         logger.debug("Request for a dataset with version: " + dataSetId);
         return metadataService.findDataSetByUuid(dataSetId);
     }
-
 
     @GetMapping("/datasets/{dataSetId}")
     @CrossOrigin
@@ -135,25 +145,33 @@ public class MetadataController {
     @GetMapping("/versions/{dataSetId}/dimensions/{dimensionId}")
     @CrossOrigin
     @Cacheable("dimensions")
-    public DimensionMetadata findDimensionByIdWithDatasetUuid(@PathVariable String dataSetId, @PathVariable String dimensionId,
+    public ResponseEntity<DimensionMetadata> findDimensionByIdWithDatasetUuid(@PathVariable String dataSetId, @PathVariable String dimensionId,
                                                @RequestParam(name = "view", defaultValue = "list") String view)
             throws DataSetNotFoundException, DimensionNotFoundException {
         logger.debug("Request for a dimension for dataset version " + dataSetId + " and dimensionId " + dimensionId);
         final DimensionViewType viewType = DimensionViewType.valueOf(view.toUpperCase());
-        return metadataService.findDimensionByIdWithDatasetUuid(dataSetId, dimensionId, viewType);
+
+        DimensionMetadata dimensionMetadata = metadataService.findDimensionByIdWithDatasetUuid(dataSetId, dimensionId, viewType);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(defaultCacheTimeMinutes, TimeUnit.MINUTES))
+                .body(dimensionMetadata);
     }
 
     @GetMapping("/datasets/{dataSetId}/editions/{edition}/versions/{version}/dimensions/{dimensionId}")
     @CrossOrigin
     @Cacheable("dimensions")
-    public DimensionMetadata findDimensionByIdWithEditionVersion(@PathVariable String dataSetId, @PathVariable String edition,
+    public ResponseEntity<DimensionMetadata> findDimensionByIdWithEditionVersion(@PathVariable String dataSetId, @PathVariable String edition,
                                                                  @PathVariable int version, @PathVariable String dimensionId,
                                                @RequestParam(name = "view", defaultValue = "list") String view)
             throws DataSetNotFoundException, DimensionNotFoundException {
         logger.debug("Request for a dataset with the following data-resource/edition/version: " +
                 String.join("/", new String[]{dataSetId, edition, Integer.toString(version)}));
         final DimensionViewType viewType = DimensionViewType.valueOf(view.toUpperCase());
-        return metadataService.findDimensionByIdWithEditionVersion(dataSetId, edition, version, dimensionId, viewType);
+
+        DimensionMetadata dimensionMetadata = metadataService.findDimensionByIdWithEditionVersion(dataSetId, edition, version, dimensionId, viewType);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(defaultCacheTimeMinutes, TimeUnit.MINUTES))
+                .body(dimensionMetadata);
     }
 
     @GetMapping("/hierarchies")
@@ -166,9 +184,12 @@ public class MetadataController {
     @GetMapping("/hierarchies/{hierarchyId}")
     @CrossOrigin
     @Cacheable("hierarchies")
-    public DimensionMetadata getHierarchy(@PathVariable String hierarchyId) throws DimensionNotFoundException {
+    public ResponseEntity<DimensionMetadata> getHierarchy(@PathVariable String hierarchyId) throws DimensionNotFoundException {
         logger.debug("Request for hierarchy " + hierarchyId);
-        return metadataService.getHierarchy(hierarchyId);
+        DimensionMetadata hierarchy = metadataService.getHierarchy(hierarchyId);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(defaultCacheTimeMinutes, TimeUnit.MINUTES))
+                .body(hierarchy);
     }
 
     @ResponseStatus(code = HttpStatus.BAD_REQUEST)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 server.port=20099
 include.geo.dimensions=false
+default.cache.time.minutes=60

--- a/src/test/java/uk/co/onsdigital/discovery/metadata/api/controller/MetadataControllerTest.java
+++ b/src/test/java/uk/co/onsdigital/discovery/metadata/api/controller/MetadataControllerTest.java
@@ -6,8 +6,11 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.testng.Assert;
 import org.testng.annotations.Test;
+import uk.co.onsdigital.discovery.metadata.api.dto.common.DimensionMetadata;
 import uk.co.onsdigital.discovery.metadata.api.service.DimensionViewType;
 import uk.co.onsdigital.discovery.metadata.api.service.MetadataService;
 
@@ -21,9 +24,13 @@ public class MetadataControllerTest extends AbstractTestNGSpringContextTests {
     @Configuration
     @EnableCaching
     static class Config {
+
+        public static final int defaultCacheTimeMinutes = 3;
+        public static final int defaultCacheTimeSeconds = defaultCacheTimeMinutes * 60;
+
         @Bean
         public MetadataController getMetadataController() {
-            return new MetadataController();
+            return new MetadataController(getMetadataService(), defaultCacheTimeMinutes);
         }
 
         @Bean
@@ -52,6 +59,21 @@ public class MetadataControllerTest extends AbstractTestNGSpringContextTests {
     }
 
     @Test
+    public void getHierarchyShouldReturnCacheControlHeaders() {
+
+        // Given a hierarchy ID we want to get.
+        String hierarchyId = "hierarchy1";
+
+        // When we call getHierarchy
+        ResponseEntity<DimensionMetadata> response = metadataController.getHierarchy(hierarchyId);
+
+        // Then the response contains cache control headers
+        String actual = response.getHeaders().get("Cache-Control").get(0);
+        String expected = String.format("max-age=%d", Config.defaultCacheTimeSeconds);
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
     public void findDimensionByIdWithDatasetUuidShouldCacheResponse() {
 
         // Given a dimension ID we want to get.
@@ -65,6 +87,23 @@ public class MetadataControllerTest extends AbstractTestNGSpringContextTests {
 
         // Then the metadata service is called only once as it is cached after the first call.
         verify(metadataService, times(1)).findDimensionByIdWithDatasetUuid(datasetId, dimensionId, DimensionViewType.HIERARCHY);
+    }
+
+    @Test
+    public void findDimensionByIdWithDatasetUuidShouldReturnCacheControlHeaders() {
+
+        // Given a dimension ID we want to get.
+        String datasetId = "datasetId";
+        String dimensionId = "dimensionId";
+        String view = "HIERARCHY";
+
+        // When we call findDimensionByIdWithDatasetUuid
+        ResponseEntity<DimensionMetadata> response = metadataController.findDimensionByIdWithDatasetUuid(datasetId, dimensionId, view);
+
+        // Then the response contains cache control headers
+        String actual = response.getHeaders().get("Cache-Control").get(0);
+        String expected = String.format("max-age=%d", Config.defaultCacheTimeSeconds);
+        Assert.assertEquals(actual, expected);
     }
 
     @Test
@@ -84,5 +123,24 @@ public class MetadataControllerTest extends AbstractTestNGSpringContextTests {
         // Then the metadata service is called only once as it is cached after the first call.
         verify(metadataService, times(1))
                 .findDimensionByIdWithEditionVersion(datasetId, edition, version, dimensionId, DimensionViewType.HIERARCHY);
+    }
+
+    @Test
+    public void findDimensionByIdWithEditionVersionShouldReturnCacheControlHeaders() {
+
+        // Given a dimension ID we want to get.
+        String datasetId = "datasetId";
+        String edition = "edition";
+        String dimensionId = "dimensionId";
+        int version = 3;
+        String view = "HIERARCHY";
+
+        // When we call findDimensionByIdWithEditionVersion multiple times
+        ResponseEntity<DimensionMetadata> response = metadataController.findDimensionByIdWithEditionVersion(datasetId, edition, version, dimensionId, view);
+
+        // Then the response contains cache control headers
+        String actual = response.getHeaders().get("Cache-Control").get(0);
+        String expected = String.format("max-age=%d", Config.defaultCacheTimeSeconds);
+        Assert.assertEquals(actual, expected);
     }
 }


### PR DESCRIPTION
### What

Provide cache control headers for hierarchy / dimension endpoints. I have selected an arbitrary 60 minute cache time. This can be changed in the application.properties file or be provided via environment variable.

### How to review

- Check the tests pass
- Check the hierarchy and dimension endpoints provide a cache control header with the expected cache time. 
- Consider if other endpoints require cache control headers. 
- Consider if the default cache time is appropriate.

### Who can review

Anyone
